### PR TITLE
Handle rejection of a transaction in Wallet Connect

### DIFF
--- a/src/lib/walletAdapters/WalletConnectAdapter.ts
+++ b/src/lib/walletAdapters/WalletConnectAdapter.ts
@@ -1,3 +1,4 @@
+import { TransactionResponse } from '@ethersproject/providers'
 import { Signer, constants, utils } from 'ethers'
 import { RIFWallet } from '../core'
 export class WalletConnectAdapter {
@@ -45,9 +46,9 @@ class SendTransactionResolver implements IResolver {
       payload.data = constants.HashZero
     }
 
-    const tx = await this.signer.sendTransaction(payload)
-
-    return tx.hash
+    return this.signer
+      .sendTransaction(payload)
+      .then((tx: TransactionResponse) => tx.hash)
   }
 }
 

--- a/src/screens/walletConnect/WalletConnectContext.tsx
+++ b/src/screens/walletConnect/WalletConnectContext.tsx
@@ -71,16 +71,12 @@ export const WalletConnectProviderElement: React.FC<WalletConnectProviderElement
 
         const { id, method, params } = payload
 
-        console.log('EVENT', 'call_request', payload)
-
-        try {
-          const result = await adapter.handleCall(method, params)
-
-          connector?.approveRequest({ id, result })
-        } catch (err) {
-          console.error(err)
-          connector?.rejectRequest({ id })
-        }
+        adapter
+          .handleCall(method, params)
+          .then((result: any) => connector?.approveRequest({ id, result }))
+          .catch((errorReason: string) =>
+            connector?.rejectRequest({ id, error: { message: errorReason } }),
+          )
       })
 
       wc.on('disconnect', async error => {


### PR DESCRIPTION
In signMessage and signTypedData requests, the response or the error was being passed to context. However, with sendTransaction, the await would fail and throw an error. The error was not caught properly causing the app to go red.

In addition, the error was not being sent back to the dapp, this is fixed too. 

## test it out

1. use the sample app: https://basic-sample.rlogin.identity.rifos.org/
2. connect via walletConnect
3. send a transaction via the first button (not ethers or web3)
4. in the app, reject the transaction
5. screenshot below
6. bonus: test rejecting personalSign and signTypedData too

## screenshot
![Screenshot 2021-11-17 at 5 52 45 PM](https://user-images.githubusercontent.com/766679/142234272-a46868a2-bd00-4834-8ee4-d7b0525b9eb0.png)

## what it doesn't do:

It only handles the eip1193 requests and does not solve the web3 or ethers issues. These will be in a different PR. 
