### PR TITLE
Convert values coming in from WalletConnect

### DIFF
--- a/src/lib/walletAdapters/WalletConnectAdapter.test.ts
+++ b/src/lib/walletAdapters/WalletConnectAdapter.test.ts
@@ -1,49 +1,99 @@
-import { Signer } from 'ethers'
+import { BigNumber, Signer } from 'ethers'
 import { getSigner } from '../../../testLib/utils'
 import { WalletConnectAdapter } from './WalletConnectAdapter'
 
-describe('Wallet Connect Adapter', () => {
-  let adapter: WalletConnectAdapter | null = null
-  let signer: Signer | null = null
-
+describe('Wallet Connect Adapter', function (this: {
+  adapter: WalletConnectAdapter
+  signer: Signer
+}) {
   beforeEach(async () => {
-    signer = getSigner(9)
-
-    adapter = new WalletConnectAdapter(signer)
+    this.signer = getSigner(9)
+    this.adapter = new WalletConnectAdapter(this.signer)
   })
 
   test('send tx', async () => {
-    const from = await signer?.getAddress()
+    const from = await this.signer.getAddress()
     const to = await getSigner(0).getAddress()
+    const chainId = await this.signer.getChainId()
 
     const method = 'eth_sendTransaction'
     const params = [
       {
-        data: '',
+        data: '0x123456789a',
         from,
         to,
         value: '0x3e8',
         gas: '25000',
         gasPrice: '60000000',
+        chainId,
       },
     ]
 
-    const result = await adapter?.handleCall(method, params)
+    const mockIt = jest.fn()
 
-    expect(result).toBeDefined()
-    expect(result).toContain('0x')
+    jest.spyOn(this.signer, 'sendTransaction').mockImplementation((tx: any) => {
+      mockIt(tx)
+      return Promise.resolve(tx)
+    })
+
+    await this.adapter.handleCall(method, params)
+
+    expect(mockIt).toBeCalledWith({
+      data: params[0].data,
+      from,
+      to,
+      chainId,
+      nonce: undefined,
+      gasPrice: BigNumber.from(params[0].gasPrice),
+      gasLimit: BigNumber.from(params[0].gas),
+      value: BigNumber.from('0x3e8'),
+    })
+  })
+
+  test('default parameters are set', async () => {
+    const method = 'eth_sendTransaction'
+
+    const from = await this.signer.getAddress()
+    const to = await getSigner(0).getAddress()
+
+    const params = [
+      {
+        to,
+        from,
+      },
+    ]
+
+    const mockIt = jest.fn()
+
+    jest.spyOn(this.signer, 'sendTransaction').mockImplementation((tx: any) => {
+      mockIt(tx)
+      return Promise.resolve(tx)
+    })
+
+    await this.adapter.handleCall(method, params)
+
+    expect(mockIt).toBeCalledWith({
+      to,
+      from,
+      data: '0x',
+      chainId: undefined,
+      gasLimit: undefined,
+      gasPrice: undefined,
+      nonce: undefined,
+      value: BigNumber.from(0),
+    })
   })
 
   // method not supported by ganache-cli
   // eslint-disable-next-line jest/no-disabled-tests
   test.skip('personal sign', async () => {
-    const from = await signer?.getAddress()
+    const from = await this.signer.getAddress()
     const message = '0x68656c6c6f20776f726c6421'
 
     const method = 'personal_sign'
     const params = [message, from]
 
-    const result = await adapter?.handleCall(method, params)
+    const result = await this.adapter.handleCall(method, params)
 
     expect(result).toBeDefined()
     expect(result).toContain('0x')
@@ -58,7 +108,7 @@ describe('Wallet Connect Adapter', () => {
       '{"domain":{"chainId":31,"name":"Ether Mail","version":"1"},"message":{"contents":"{     from: {         name: \'Cow\',         wallet: \'0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\'     },     to: {         name: \'Bob\',         wallet: \'0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB\'     },     contents: \'Hello, Bob!\' }","from":"Diego","to":"Cesar"},"primaryType":"Mail","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"}],"Mail":[{"name":"from","type":"string"},{"name":"to","type":"string"},{"name":"contents","type":"string"}]}}',
     ]
 
-    const result = await adapter?.handleCall(method, params)
+    const result = await this.adapter.handleCall(method, params)
 
     expect(result).toBeDefined()
     expect(result).toContain('0x')

--- a/src/lib/walletAdapters/WalletConnectAdapter.ts
+++ b/src/lib/walletAdapters/WalletConnectAdapter.ts
@@ -1,6 +1,6 @@
 import { TransactionResponse } from '@ethersproject/providers'
 import { TransactionRequest } from '@ethersproject/abstract-provider'
-import { Signer, constants, utils, BigNumber } from 'ethers'
+import { Signer, utils, BigNumber } from 'ethers'
 import { RIFWallet } from '../core'
 export class WalletConnectAdapter {
   private resolvers: IResolver[]
@@ -46,11 +46,11 @@ class SendTransactionResolver implements IResolver {
       to: payload.to,
       from: payload.from,
       nonce: payload.nonce,
-      data: payload.data || constants.HashZero,
+      data: payload.data || '0x',
       value: BigNumber.from(payload.value || 0),
       chainId: payload.chainId,
-      gasLimit: BigNumber.from(payload.gas || 0), // WC's gas to gasLimit
-      gasPrice: BigNumber.from(payload.gasPrice || 0),
+      gasLimit: payload.gas ? BigNumber.from(payload.gas) : undefined, // WC's gas to gasLimit
+      gasPrice: payload.gasPrice ? BigNumber.from(payload.gasPrice) : undefined,
     }
 
     return this.signer


### PR DESCRIPTION
~Convert values coming from WalletConnect to integers which is what is expected. Also, delete the `gas` property as this was also causing ethers to fail.~

~This uses BigNumber's `from` method to handle the conversion to BigNumber then back to number. We could extract out the `from` portion if it would make it faster.~

**Update:**

* Take WC object and conform it to a `TransactionRequest` including renaming `gas` to `gasLimit`. 
* Leave numbers as BigNumber and allow UI to change them toString().
* **does not estimate gas** - The UI currently looks to see if the gasLimit and gasPrice is set and if not, it estimates them, since both numbers here are being passed as 0 if they don't exist, it would estimate it. #72 will estimate regardless and will take the higher value, therefor, I will leave this 'bug' here.


**notes**

- This was tested with the Basic Sample App with all three "sendTransaction" buttons. While it is not required to have these changes, it will make it easier: https://github.com/rsksmart/rLogin-sample-apps/pull/48
- Tested in the [compatibility app](https://rsksmart.github.io/rLogin-web3-clients-compatibility-tests/) and all values showed up in the modal as expected.
- this PR does not fix the gasEstimation issue reported in #20