### PR TITLE
Allow for decimals to be null and use 0 instead

### DIFF
--- a/src/screens/balances/BalancesScreen.tsx
+++ b/src/screens/balances/BalancesScreen.tsx
@@ -30,7 +30,7 @@ export const BalancesRow = ({
   <View style={styles.tokenRow} testID={`${contractAddress}.View`}>
     <View style={styles.tokenBalance}>
       <Text testID={`${contractAddress}.Text`}>
-        {`${balanceToString(balance, decimals)} ${symbol}`}
+        {`${balanceToString(balance, decimals || 0)} ${symbol}`}
       </Text>
     </View>
     <View style={styles.button}>


### PR DESCRIPTION
I sent an ERC721 (i.e. an NFT) to my smartwallet which does not usually have a decimals value. This broke the UI, so here I have it fallback to zero if is not set.

See TACO:

![Screen Shot 2022-01-12 at 3 21 13 PM](https://user-images.githubusercontent.com/766679/149148202-1644f8f3-5b5b-4026-a515-8a4d9a46d631.png)
 