### PR TITLE
Adding network info to app header

### DIFF
--- a/src/ux/appHeader/index.tsx
+++ b/src/ux/appHeader/index.tsx
@@ -1,20 +1,47 @@
 import { useNavigation } from '@react-navigation/core'
 import React from 'react'
-import { View, StyleSheet, TouchableOpacity } from 'react-native'
+import { View, StyleSheet, TouchableOpacity, Text } from 'react-native'
 import { AddressCopyComponent } from '../../components/copy/AddressCopyComponent'
 import { useSelectedWallet } from '../../Context'
 import MenuIcon from './MenuIcon'
+import { Network } from '@ethersproject/networks'
+
+export const networks: Record<number, Network> = {
+  30: {
+    chainId: 30,
+    name: 'RSK Mainnet',
+  },
+  31: {
+    chainId: 31,
+    name: 'RSK Testnet',
+  },
+}
 
 export const AppHeader: React.FC<{}> = () => {
   const { wallet } = useSelectedWallet()
 
   const navigation = useNavigation()
   const openMenu = () => navigation.navigate('Settings' as any)
+  const [network, setNetwork] = React.useState<null | Network>(null)
+
+  const handleNetworkInfo = async () => {
+    const network = await wallet.provider?.getNetwork()
+    setNetwork(networks[(network as Network).chainId])
+  }
+
+  React.useEffect(() => {
+    handleNetworkInfo()
+  }, [wallet])
 
   return (
     <View style={styles.row}>
-      <View style={styles.column}>
+      <View
+        style={{
+          ...styles.column,
+          ...styles.walletInfo,
+        }}>
         {wallet && <AddressCopyComponent address={wallet.smartWalletAddress} />}
+        {network && <Text>{network.name}</Text>}
       </View>
       <View style={styles.column}>
         <TouchableOpacity onPress={openMenu} style={styles.menu}>
@@ -27,6 +54,7 @@ export const AppHeader: React.FC<{}> = () => {
 
 const styles = StyleSheet.create({
   row: {
+    alignItems: 'center',
     padding: 10,
     display: 'flex',
     flexDirection: 'row',
@@ -35,6 +63,10 @@ const styles = StyleSheet.create({
     display: 'flex',
     paddingRight: 5,
     width: '50%',
+  },
+  walletInfo: {
+    alignItems: 'center',
+    flexDirection: 'row',
   },
   menu: {
     alignItems: 'flex-end',


### PR DESCRIPTION
Added function `handleNetworkInfo` to retrieve wallet network information from the wallet provider.

*Note:* `wallet.provider?.getNetwork()`is not returning the correct information for testnet, this is what's returning the following:

`{“chainId”: 31, “name”: “unknown”}`

That's why I had to add the networks variable, to handle mainnet and testnet.
```
export const networks: Record<number, Network> = {
  30: {
    chainId: 30,
    name: 'RSK Mainnet',
  },
  31: {
    chainId: 31,
    name: 'RSK Testnet',
  },
}
```

![image](https://user-images.githubusercontent.com/32603375/150589278-765f2080-f6d7-4468-b10f-72dd839fee00.png)
