### PR TITLE
Add faucet component to the App's home screen

### DIFF
--- a/src/screens/home/FaucetComponent.test.tsx
+++ b/src/screens/home/FaucetComponent.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import FaucetComponent from './FaucetComponent'
+
+describe('FaucetComponent', () => {
+  const navigation = {
+    navigate: jest.fn(),
+  }
+
+  it('shows rbtc', () => {
+    const { getByTestId } = render(
+      <FaucetComponent
+        rbtcBalance={0}
+        rifBalance={0}
+        navigation={navigation}
+      />,
+    )
+
+    expect(getByTestId('Faucet.Text').children[0]).toBe(
+      "Your wallet doesn't have any TRBTC. Click here to get some from the faucet!",
+    )
+
+    fireEvent.press(getByTestId('Faucet.Text'))
+
+    expect(navigation.navigate).toBeCalledWith('InjectedBrowserUX', {
+      params: { uri: 'https://faucet.rsk.co/' },
+      screen: 'InjectedBrowser',
+    })
+  })
+
+  it('shows tRIF', () => {
+    const { getByTestId } = render(
+      <FaucetComponent
+        rbtcBalance={1}
+        rifBalance={0}
+        navigation={navigation}
+      />,
+    )
+
+    expect(getByTestId('Faucet.Text').children[0]).toBe(
+      "Your wallet doesn't have any tRIF. Click here to get some from the faucet!",
+    )
+
+    fireEvent.press(getByTestId('Faucet.Text'))
+
+    expect(navigation.navigate).toBeCalledWith('InjectedBrowserUX', {
+      params: { uri: 'https://faucet.rifos.org/' },
+      screen: 'InjectedBrowser',
+    })
+  })
+
+  it('shows nothing', () => {
+    const { queryAllByTestId } = render(
+      <FaucetComponent
+        rbtcBalance={1}
+        rifBalance={1}
+        navigation={navigation}
+      />,
+    )
+
+    expect(queryAllByTestId('Faucet.Text')).toMatchObject([])
+  })
+})

--- a/src/screens/home/FaucetComponent.tsx
+++ b/src/screens/home/FaucetComponent.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { TouchableOpacity } from 'react-native-gesture-handler'
+import { TokenImage } from './TokenImage'
+
+interface Interface {
+  navigation: any
+  rbtcBalance: number
+  rifBalance: number
+}
+
+const FaucetComponent: React.FC<Interface> = ({
+  rbtcBalance,
+  rifBalance,
+  navigation,
+}) => {
+  if (rbtcBalance === 0 || rifBalance === 0) {
+    const token = rbtcBalance === 0 ? 'TRBTC' : 'tRIF'
+
+    const handleClick = () =>
+      navigation.navigate('InjectedBrowserUX', {
+        screen: 'InjectedBrowser',
+        params: {
+          uri:
+            token === 'TRBTC'
+              ? 'https://faucet.rsk.co/'
+              : 'https://faucet.rifos.org/',
+        },
+      })
+
+    return (
+      <TouchableOpacity style={styles.background} onPress={handleClick}>
+        <View style={styles.iconContainer}>
+          <TokenImage symbol={token} width={45} height={45} />
+        </View>
+        <View style={styles.textContainer}>
+          <Text testID="Faucet.Text">
+            {`Your wallet doesn't have any ${token}. Click here to get some from the faucet!`}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    )
+  }
+
+  return <></>
+}
+
+const styles = StyleSheet.create({
+  background: {
+    backgroundColor: 'rgba(255, 255, 255, .55)',
+    borderColor: 'rgba(0, 0, 0, .1)',
+    borderWidth: 1,
+    padding: 20,
+    marginHorizontal: 25,
+    marginTop: 25,
+    borderRadius: 10,
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  iconContainer: {
+    display: 'flex',
+    flex: 2,
+  },
+  textContainer: {
+    display: 'flex',
+    flex: 8,
+  },
+})
+
+export default FaucetComponent

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -9,6 +9,8 @@ import LinearGradient from 'react-native-linear-gradient'
 import { getTokenColor, setOpacity } from './tokenColor'
 import PortfolioComponent from './PortfolioComponent'
 import ActivityComponent from './ActivityComponent'
+import FaucetComponent from './FaucetComponent'
+import { ScrollView } from 'react-native-gesture-handler'
 
 export const HomeScreen: React.FC<{
   navigation: NavigationProp
@@ -28,24 +30,32 @@ export const HomeScreen: React.FC<{
     <LinearGradient
       colors={['#FFFFFF', setOpacity(selectedTokenColor, 0.1)]}
       style={styles.parent}>
-      <SelectedTokenComponent navigation={navigation} token={selected} />
-
-      <LinearGradient
-        colors={['#FFFFFF', '#E1E1E1']}
-        style={{ ...styles.topContainer, ...containerStyles }}>
-        <PortfolioComponent
-          setPanelActive={() => setSelectedPanel('portfolio')}
-          balances={balances}
-          selected={selected}
-          setSelected={setSelected}
-          visible={selectedPanel === 'portfolio'}
-        />
-        <ActivityComponent
+      <ScrollView>
+        <FaucetComponent
           navigation={navigation}
-          setPanelActive={() => setSelectedPanel('transactions')}
-          visible={selectedPanel === 'transactions'}
+          rbtcBalance={0}
+          rifBalance={0}
         />
-      </LinearGradient>
+
+        <SelectedTokenComponent navigation={navigation} token={selected} />
+
+        <LinearGradient
+          colors={['#FFFFFF', '#E1E1E1']}
+          style={{ ...styles.topContainer, ...containerStyles }}>
+          <PortfolioComponent
+            setPanelActive={() => setSelectedPanel('portfolio')}
+            balances={balances}
+            selected={selected}
+            setSelected={setSelected}
+            visible={selectedPanel === 'portfolio'}
+          />
+          <ActivityComponent
+            navigation={navigation}
+            setPanelActive={() => setSelectedPanel('transactions')}
+            visible={selectedPanel === 'transactions'}
+          />
+        </LinearGradient>
+      </ScrollView>
     </LinearGradient>
   )
 }


### PR DESCRIPTION
Adds links to both faucets when the app detects a zero balance.

- For testing, this should be triggered via code. Waiting for home prices to continue.
- Design is minimal since expecting changes coming. 

Also added `<ScrollView>` to the App's home so the user can still see the static transactions. 

![Screen Shot 2022-01-27 at 2 38 16 PM](https://user-images.githubusercontent.com/766679/151360402-3b472f97-29bb-4316-a34c-79afe9865e70.png)

![Screen Shot 2022-01-27 at 2 38 31 PM](https://user-images.githubusercontent.com/766679/151360444-52cf5ab7-f1a2-4312-bd05-c85d0285b4cc.png)

## checklist:

- [ ] Check against the live prices
