### PR TITLE
Refactor save pin operation

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -355,7 +355,7 @@ PODS:
     - React-cxxreact (= 0.65.1)
     - React-jsi (= 0.65.1)
     - React-perflogger (= 0.65.1)
-  - RNCAsyncStorage (1.16.0):
+  - RNCAsyncStorage (1.15.14):
     - React-Core
   - RNCClipboard (1.5.1):
     - React-Core
@@ -583,7 +583,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 92d41c2442e5328cc4d342cd7f78e5876b68bae5
   React-runtimeexecutor: 85187f19dd9c47a7c102f9994f9d14e4dc2110de
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
-  RNCAsyncStorage: 848b2c311517837ed36b92aa9b2f40ae3b5812ba
+  RNCAsyncStorage: ea6b5c280997b2b32a587793163b1f10e580c4f7
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNSecureStorage: 8b2b07278d80c48b3a881c56e604ab147372f243
@@ -593,4 +593,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: cf6365a365ec4dda2996d9f451da6d0869fe6cc8
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/ios/sWallet.xcodeproj/project.pbxproj
+++ b/ios/sWallet.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -629,7 +629,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/src/RootNavigation.tsx
+++ b/src/RootNavigation.tsx
@@ -99,7 +99,7 @@ export const RootNavigation: React.FC<{
   hasPin: boolean
   rifWalletServicesSocket: IRifWalletServicesSocket
   keyManagementProps: CreateKeysProps
-  handlePinCreated: () => void
+  createPin: (newPin: string) => Promise<void>
   balancesScreenProps: BalancesScreenProps
   activityScreenProps: ActivityScreenProps
   keysInfoScreenProps: KeysInfoScreenProps
@@ -114,7 +114,7 @@ export const RootNavigation: React.FC<{
   hasKeys,
   hasPin,
   keyManagementProps,
-  handlePinCreated,
+  createPin,
   balancesScreenProps,
   activityScreenProps,
   keysInfoScreenProps,
@@ -257,7 +257,7 @@ export const RootNavigation: React.FC<{
           {props => (
             <Screens.CreatePinScreen
               {...props}
-              onPinCreated={handlePinCreated}
+              createPin={createPin}
             />
           )}
         </RootStack.Screen>

--- a/src/components/PinManager/index.tsx
+++ b/src/components/PinManager/index.tsx
@@ -8,7 +8,7 @@ import { colors } from '../../styles/colors'
 
 interface Interface {
   title: string
-  handleSubmit: (enteredPin: string) => Promise<string>
+  handleSubmit: (enteredPin: string) => Promise<void>
 }
 export const PinManager: React.FC<Interface> = ({ title, handleSubmit }) => {
   const [error, setError] = useState<string | null>(null)
@@ -16,12 +16,6 @@ export const PinManager: React.FC<Interface> = ({ title, handleSubmit }) => {
   const [position, setPosition] = React.useState(0)
 
   const { t } = useTranslation()
-
-  const onSubmit = (enteredPin: string) => () => {
-    handleSubmit(enteredPin).then((response: string) => {
-      console.log(response)
-    })
-  }
 
   const onPressKey = (value: string) => {
     setPin(prev => {
@@ -69,7 +63,7 @@ export const PinManager: React.FC<Interface> = ({ title, handleSubmit }) => {
       <KeyPad
         onDelete={onDelete}
         onKeyPress={onPressKey}
-        onUnlock={onSubmit(pin.join(''))}
+        onUnlock={() => handleSubmit(pin.join(''))}
       />
     </View>
   )

--- a/src/screens/createPin/CreatePinScreen.tsx
+++ b/src/screens/createPin/CreatePinScreen.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
-import { savePin } from '../../storage/PinStore'
 import { PinManager } from '../../components/PinManager'
 
 interface Interface {
-  onPinCreated: () => void
+  createPin: (newPin: string) => Promise<void>
 }
 
-export const CreatePinScreen: React.FC<Interface> = ({ onPinCreated }) => {
+export const CreatePinScreen: React.FC<Interface> = ({ createPin }) => {
   const onSubmit = async (enteredValue: string) => {
-    await savePin(enteredValue)
-    await onPinCreated()
+    await createPin(enteredValue)
     return 'Pin Created'
   }
-  return <PinManager title={'Set your pin'} handleSubmit={onSubmit} />
+  return <PinManager title={'Set your pin'} handleSubmit={createPin} />
 }


### PR DESCRIPTION
We are moving both `savePin` and `setState({ hasPin: true })` to a single place to make `CreatePinScreen` visual-only. Now `savePin` has single responsibility of updating both storage and state