### PR TITLE
Added text components for the typography guidelines we'll be using

### DIFF
--- a/src/components/typography/CustomText.tsx
+++ b/src/components/typography/CustomText.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Text } from 'react-native'
+
+type CustomTextType = {
+  font: string
+}
+
+export type TextType = {
+  children: React.ReactNode
+  [key: string]: any
+}
+const CustomText: React.FC<CustomTextType & TextType> = ({
+  font,
+  children,
+  ...props
+}) => {
+  const { style, ...rest } = props
+  // Avoids overriding the font when passing style unless the developer does it
+  const fontStyle = {
+    fontFamily: font,
+    ...(style && { ...style }),
+  }
+  return (
+    <Text style={fontStyle} {...rest}>
+      {children}
+    </Text>
+  )
+}
+
+export default CustomText

--- a/src/components/typography/MediumText.tsx
+++ b/src/components/typography/MediumText.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { fonts } from '../../styles/fonts'
+import CustomText, { TextType } from './CustomText'
+
+const MediumText: React.FC<TextType> = ({ children, ...props }) => (
+  <CustomText font={fonts.medium} {...props}>
+    {children}
+  </CustomText>
+)
+
+export default MediumText

--- a/src/components/typography/RegularText.tsx
+++ b/src/components/typography/RegularText.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { fonts } from '../../styles/fonts'
+import CustomText, { TextType } from './CustomText'
+
+const RegularText: React.FC<TextType> = ({ children, ...props }) => (
+  <CustomText font={fonts.regular} {...props}>
+    {children}
+  </CustomText>
+)
+
+export default RegularText

--- a/src/components/typography/SemiBoldText.tsx
+++ b/src/components/typography/SemiBoldText.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { fonts } from '../../styles/fonts'
+import CustomText, { TextType } from './CustomText'
+
+const SemiBoldText: React.FC<TextType> = ({ children, ...props }) => (
+  <CustomText font={fonts.semibold} {...props}>
+    {children}
+  </CustomText>
+)
+
+export default SemiBoldText

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -53,6 +53,10 @@ export const CompactParagraph: React.FC<Interface> = ({ children, testID }) => (
   </Text>
 )
 
+export { default as RegularText } from './RegularText'
+export { default as MediumText } from './MediumText'
+export { default as SemiBoldText } from './SemiBoldText'
+
 const styles = StyleSheet.create({
   header1: {
     fontSize: 42,


### PR DESCRIPTION
I've created 3 components which are the fonts types we'll be using.

For each one, it utilizes a parent component CustomText which will be in charge of doing the styles logic.

If the developer passes a style prop and overrides the font, then it'll be overriden, else it'll use the default ones (Poppins)