### PR TITLE
Correctly estimate rBTC gas estimation

### DIFF
--- a/src/lib/core/RIFWallet.ts
+++ b/src/lib/core/RIFWallet.ts
@@ -115,6 +115,14 @@ export class RIFWallet extends Signer implements TypedDataSigner {
   sendTransaction = this.createDoRequest(
     'sendTransaction',
     (([transactionRequest]: [TransactionRequest], overriddenOptions?: Partial<OverriddableTransactionOptions>) => {
+      // check if attempting to send rBTC from the EOA account
+      if (!transactionRequest.data && !!transactionRequest.value && !!transactionRequest.to) {
+        return this.smartWallet.signer.sendTransaction({
+          to: transactionRequest.to.toLowerCase(),
+          value: transactionRequest.value
+        })
+      }
+
       const txOptions = {
         ...filterTxOptions(transactionRequest),
         ...overriddenOptions || {}


### PR DESCRIPTION
Instead of trying to estimate the correct price with delegateCall, send the rBTC directly from the EOA wallet. Check if the user is trying to send rBTC from their EOA account and if so, don't send it to the smartWallet.

There is a larger decision on where the rBTC should be stored and until RIF Relay server is setup, the rBTC is loaded from the EOA account. This code may be removed in the future if rBTC sit in the SmartWallet and not the EOA account.

**to test**

- have rBTC in your EOA account
- send that rBTC to someone, expected gas is around 21k,
- transaction should be successful

**what is missing**

Since the transaction does not go through the SmartWallet, these transactions will not show up in the Activity. This is okay for now as we decide where the rBTC should be stored.