### PR TITLE
Moved global error handler inside the provider

### DIFF
--- a/src/components/GlobalErrorHandler/GlobalErrorHandlerContext.tsx
+++ b/src/components/GlobalErrorHandler/GlobalErrorHandlerContext.tsx
@@ -29,14 +29,11 @@ const GlobalErrorHandlerProvider: React.FC<GlobalErrorHandlerProviderType> = ({
     setCompKey(curKey => curKey + 1)
   }
 
-  if (globalError) {
-    return <GlobalErrorHandlerViewComp />
-  }
   return (
     <GlobalErrorHandlerContext.Provider
       value={{ setGlobalError, globalError, handleReload }}
       key={compKey}>
-      {children}
+      {globalError ? <GlobalErrorHandlerViewComp /> : children}
     </GlobalErrorHandlerContext.Provider>
   )
 }


### PR DESCRIPTION
Moved global error handler inside the provider - it was not using the globalError message because it was outside the provider.