### PR TITLE
Center PIN screen on start and when changing pin.

### DIFF
--- a/src/components/PinManager/PinScreen/PinDefaultView.tsx
+++ b/src/components/PinManager/PinScreen/PinDefaultView.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { KeyPad } from '../../keyPad'
 import { StyleSheet, View } from 'react-native'
 import DotsComponentDefault from './DotsComponent'
-import { shareStyles } from '../../sharedStyles'
 import { PinScreenType, DotsComponentDefaultType } from './PinScreen'
 import MessageComponentDefault from './MessageComponent'
 import { colors } from '../../../styles'
@@ -17,14 +16,14 @@ const PinScreen: React.FC<PinScreenType & DotsComponentDefaultType> = ({
   error = null,
 }) => {
   return (
-    <View style={[shareStyles.coverAllScreen, styles.container]}>
+    <View style={styles.container}>
       <View style={styles.messageView}>
         <MessageComponent message={error || undefined} />
       </View>
-      <View style={styles.dotsView}>
+      <View>
         <DotsComponent pin={pin} />
       </View>
-      <View style={styles.keypadView}>
+      <View>
         <KeypadComponent onDelete={onKeypadDelete} onKeyPress={onKeypadPress} />
       </View>
     </View>
@@ -33,14 +32,16 @@ const PinScreen: React.FC<PinScreenType & DotsComponentDefaultType> = ({
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    flexDirection: 'column',
+    height: '100%',
     backgroundColor: colors.darkPurple3,
-    position: 'absolute',
-    zIndex: 3,
+    justifyContent: 'center',
     paddingHorizontal: 40,
   },
-  messageView: { flex: 1.5, justifyContent: 'flex-end', marginBottom: 20 },
-  dotsView: { flex: 1 },
-  keypadView: { flex: 4 },
+  messageView: {
+    marginBottom: 20,
+  },
 })
 
 export default PinScreen

--- a/src/core/Core.tsx
+++ b/src/core/Core.tsx
@@ -111,6 +111,10 @@ export const Core = () => {
     },
   })
 
+  if (state.hasKeys && state.hasPin && !unlocked) {
+    return <RequestPIN unlock={onScreenUnlock} />
+  }
+
   return (
     <Fragment>
       <SafeAreaView style={styles.top}>
@@ -118,9 +122,6 @@ export const Core = () => {
       </SafeAreaView>
       <SafeAreaView style={styles.body}>
         {!active && <Cover />}
-        {state.hasKeys && state.hasPin && !unlocked && (
-          <RequestPIN unlock={onScreenUnlock} />
-        )}
         <AppContext.Provider
           value={{
             ...state,


### PR DESCRIPTION
Move the 'request' PIN Screen outside of the navigation which was causing style issues. This will make the rest of the app rerender, yes, but the app needs to load from the server and internal database so this isn't an inconvenience. Next, update the styles on the PinView to remove absolute position and flex and allow containers to determine size based on their height.

Tested with iOS and Android simulators with both the starting pin screen and the change pin screen.

## Android:

![Screen Shot 2022-09-30 at 4 32 20 PM](https://user-images.githubusercontent.com/766679/193281324-13e47190-93e5-44fe-85d6-16a4843ffef3.png) ![Screen Shot 2022-09-30 at 4 31 39 PM](https://user-images.githubusercontent.com/766679/193281332-ea17ecf1-8caf-4ae6-af67-4a345825c7d9.png)

## iOS, two sizes

![Screen Shot 2022-09-30 at 4 21 57 PM](https://user-images.githubusercontent.com/766679/193281338-a95e13b2-206b-44f2-b017-1169b39307b6.png)
