### PR TITLE
US-1161 - Will now show address tab only when bitcoin is selected.

### DIFF
--- a/src/screens/send/TransactionForm.tsx
+++ b/src/screens/send/TransactionForm.tsx
@@ -11,6 +11,7 @@ import AssetChooser from './AssetChooser'
 import { RecentTransactions } from './RecentTransactions'
 import { SetAmountHOCComponent } from './SetAmountHOCComponent'
 import { MixedTokenAndNetworkType } from './types'
+import { useTokenSelectedTabs } from './useTokenSelectedTabs'
 
 interface Interface {
   onConfirm: (
@@ -30,6 +31,11 @@ interface Interface {
   onTokenSelected?: (tokenSelected: MixedTokenAndNetworkType) => void
 }
 
+interface txDetail {
+  value: string
+  isValid: boolean
+}
+
 const TransactionForm: React.FC<Interface> = ({
   initialValues,
   tokenList,
@@ -44,10 +50,7 @@ const TransactionForm: React.FC<Interface> = ({
   )
 
   const [activeTab, setActiveTab] = useState('address')
-  interface txDetail {
-    value: string
-    isValid: boolean
-  }
+  const { tabs } = useTokenSelectedTabs(selectedToken, setActiveTab)
 
   const [amount, setAmount] = useState<txDetail>({
     value: initialValues.amount || '0',
@@ -84,7 +87,13 @@ const TransactionForm: React.FC<Interface> = ({
     onConfirm(selectedToken, amount.value, to.value)
 
   const onTokenSelect = React.useCallback((token: MixedTokenAndNetworkType) => {
-    setSelectedToken(token)
+    setSelectedToken(oldToken => {
+      // Reset address when token type is changed
+      if ('isBitcoin' in oldToken === !('isBitcoin' in token)) {
+        handleTargetAddressChange('', false)
+      }
+      return token
+    })
     if (onTokenSelected) {
       onTokenSelected(token)
     }
@@ -113,7 +122,7 @@ const TransactionForm: React.FC<Interface> = ({
       <View>
         <Tabs
           title={'recipient'}
-          tabs={['address', 'recent', 'contact']}
+          tabs={tabs}
           selectedTab={activeTab}
           onTabSelected={setActiveTab}
         />

--- a/src/screens/send/useTokenSelectedTabs.tsx
+++ b/src/screens/send/useTokenSelectedTabs.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+import { MixedTokenAndNetworkType } from './types'
+
+const normalTabs = ['address', 'recent', 'contact']
+const bitcoinTabs = ['address']
+export const useTokenSelectedTabs = (
+  tokenSelected: MixedTokenAndNetworkType,
+  setCurrentTab: (tab: string) => void,
+) => {
+  const [tabs, setTabs] = useState<string[]>(normalTabs)
+
+  const onTokenChanged = () => {
+    if ('isBitcoin' in tokenSelected) {
+      setTabs([...bitcoinTabs])
+      setCurrentTab('address')
+    } else {
+      setTabs([...normalTabs])
+    }
+  }
+  useEffect(() => {
+    onTokenChanged()
+  }, [tokenSelected])
+  return {
+    tabs,
+  }
+}


### PR DESCRIPTION
Will now show address tab when bitcoin is selected. Will also reset address to '' if token type is changed (from bitcoin to rsk and vice-versa)

![image](https://user-images.githubusercontent.com/39339295/201380921-b604b9ca-8633-430c-876d-cbc1d915de12.png)
![image](https://user-images.githubusercontent.com/39339295/201380961-1988139c-3d9b-406b-be7d-ae958fd2346c.png)

This video shows how the address is set to '' when token is changed:

https://user-images.githubusercontent.com/39339295/201381674-4184a422-8946-4c98-8b52-4c53a02341ee.mp4


