### PR TITLE
US-1121 - Cache the private key of the wallet to speed up launch

### DIFF
--- a/src/lib/core/KeyManagementSystem.ts
+++ b/src/lib/core/KeyManagementSystem.ts
@@ -4,9 +4,9 @@ import { getDPathByChainId } from '@rsksmart/rlogin-dpath'
 
 type Mnemonic = string
 
-type DerivedPaths = { [derivatoinPath: string]: string }
+interface DerivedPaths { [derivatoinPath: string]: string }
 
-type LastDerivedAccountIndex = {
+interface LastDerivedAccountIndex {
   [chainId: number]: number
 }
 


### PR DESCRIPTION
Caching the wallet's private key results in a much quicker recreation of the Wallet.

In my few tests, with the private key it will increases the time to generate wallet from 2.5 seconds to 140 miliseconds.

To see this change, the user (or you the developer) **must reset the app and import from mnemonic** which will resave the privateKey in storage. This is why the try/catch is in there. 

If the user has the older version boolean variable (`true`) it will still take the longer route, i.e. the catch. Since there are no real users as of this point, I don't think we need to worry about an upgrade path for them. I can just tell them, and you!

## Before:

https://user-images.githubusercontent.com/766679/208119416-7a43a707-16f6-464b-97d3-93db0a795ebf.mov

## After:

https://user-images.githubusercontent.com/766679/208119521-0da61f05-101d-4e7d-b2b0-89ba0035c51a.mov

