### PR TITLE
feat: SUPERPOWERS: eslint will now let the developer know about the import orders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,64 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': ['error'],
     '@typescript-eslint/no-empty-function': 'off',
+    'import/order': [
+      'off',
+      {
+        groups: [
+          'external',
+          'builtin',
+          'internal',
+          ['sibling', 'parent'],
+          'index',
+        ],
+        pathGroups: [
+          {
+            pattern: 'lib/**',
+            group: 'internal',
+            position: 'before',
+          },
+          {
+            pattern: 'src/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'components/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'shared/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'store/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'storage/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'navigation/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'screens/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'core/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'testLib/**',
+            group: 'internal',
+          },
+        ],
+        'newlines-between': 'always',
+        warnOnUnassignedImports: true,
+        pathGroupsExcludedImportTypes: [],
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
In case we wan to fix all files: yarn lint --fix --rule "import/order: warn"

This should help us to actually follow the import order. We might just have it off, and, while developing, we can turn it to "warn" or "error", that way we'll be certain that what we're importing is in the correct order.