### PR TITLE
Add chainId back to Redux Settings slice to fix Receive Screen 

### DIFF
--- a/src/core/Core.tsx
+++ b/src/core/Core.tsx
@@ -40,12 +40,11 @@ import {
   selectSettingsIsLoading,
   selectTopColor,
   selectWallets,
-  setChainType,
+  setChainId,
   unlockApp,
 } from 'store/slices/settingsSlice'
 import { hasKeys, hasPin } from 'storage/MainStorage'
 import { BitcoinProvider } from 'core/hooks/bitcoin/BitcoinContext'
-import { ChainTypeEnum } from 'store/slices/settingsSlice/types'
 
 export const navigationContainerRef =
   createNavigationContainerRef<RootStackParamList>()
@@ -93,11 +92,7 @@ export const Core = () => {
 
   const retrieveChainId = async (wallet: RIFWallet) => {
     const chainId = await wallet.getChainId()
-    dispatch(
-      setChainType(
-        chainId === 31 ? ChainTypeEnum.TESTNET : ChainTypeEnum.MAINNET,
-      ),
-    )
+    dispatch(setChainId(chainId))
   }
 
   useRifSockets({

--- a/src/redux/slices/settingsSlice/index.ts
+++ b/src/redux/slices/settingsSlice/index.ts
@@ -134,8 +134,10 @@ const settingsSlice = createSlice({
     closeRequest: state => {
       state.requests = []
     },
-    setChainType: (state, { payload }: PayloadAction<ChainTypeEnum>) => {
-      state.chainType = payload
+    setChainId: (state, { payload }: PayloadAction<number>) => {
+      state.chainId = payload
+      state.chainType =
+        payload === 31 ? ChainTypeEnum.TESTNET : ChainTypeEnum.MAINNET
     },
     setPinState: (_, { payload }: PayloadAction<string>) => {
       savePin(payload)
@@ -223,7 +225,7 @@ export const {
   setKeysState,
   setPinState,
   setNewWallet,
-  setChainType,
+  setChainId,
   setWalletIsDeployed,
   removeKeysFromState,
   resetKeysAndPin,

--- a/src/redux/slices/settingsSlice/selectors.ts
+++ b/src/redux/slices/settingsSlice/selectors.ts
@@ -28,6 +28,7 @@ export const selectActiveWallet = ({ settings }: RootState) => ({
       ? settings.walletsIsDeployed[settings.selectedWallet]
       : null,
   chainType: settings.chainType,
+  chainId: settings.chainId,
   activeWalletIndex:
     settings.selectedWallet && settings.wallets
       ? Object.keys(settings.wallets).indexOf(settings.selectedWallet)

--- a/src/redux/slices/settingsSlice/types.ts
+++ b/src/redux/slices/settingsSlice/types.ts
@@ -48,5 +48,6 @@ export interface SettingsSlice {
   walletsIsDeployed: WalletsIsDeployed | null
   selectedWallet: string
   loading: boolean
+  chainId?: number
   chainType: ChainTypeEnum
 }


### PR DESCRIPTION
Add back in chainId property that was removed. Move the network type to redux and out of core.

This fixes the issue of the receive screen not working.