### PR TITLE
US-1391 - added QRGenerator component

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-native-mmkv": "^2.4.3",
     "react-native-modal": "^13.0.1",
     "react-native-progress": "^5.0.0",
+    "react-native-qrcode-svg": "^6.2.0",
     "react-native-randombytes": "^3.0.0",
     "react-native-reanimated": "2.12.0",
     "react-native-safe-area-context": "^4.4.1",

--- a/src/components/QRGenerator/QRGenerator.tsx
+++ b/src/components/QRGenerator/QRGenerator.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, useMemo, useCallback } from 'react'
+import {
+  ImageSourcePropType,
+  LayoutChangeEvent,
+  View,
+  ViewStyle,
+} from 'react-native'
+import QRCode from 'react-native-qrcode-svg'
+import { Icon } from 'react-native-vector-icons/Icon'
+
+import { sharedColors } from 'shared/constants'
+
+interface QRIconProps {
+  name: string
+  color: string
+  Component: typeof Icon
+}
+interface QRGeneratorProps {
+  value: string
+  iconProps?: QRIconProps
+  imageSource?: ImageSourcePropType
+  qrWidth?: number
+  qrBackgroundColor?: string
+  qrColor?: string
+  qrMargin?: number
+  logoBackgroundColor?: string
+  containerViewStyle?: ViewStyle
+}
+
+/**
+ * QR Generator
+ * @param qrWidth - if undefined - it'll take the view available space
+ * @param iconProps
+ * @param imageSource - iconProps will override this imageSource
+ * @param value
+ * @param qrBackgroundColor
+ * @param qrColor
+ * @param qrMargin
+ * @param containerViewStyle
+ * @param logoBackgroundColor
+ */
+export const QRGenerator = ({
+  value,
+  qrWidth = 100,
+  iconProps,
+  imageSource,
+  qrBackgroundColor = sharedColors.inputInactive,
+  qrColor = sharedColors.qrColor,
+  qrMargin = 10,
+  containerViewStyle,
+  logoBackgroundColor,
+}: QRGeneratorProps) => {
+  const [width, setWidth] = useState(qrWidth)
+  const [iconSource, setIconSource] = useState(imageSource)
+
+  const onWidthChange = useCallback(
+    (e: LayoutChangeEvent) => {
+      if (qrWidth === undefined) {
+        setWidth(e.nativeEvent.layout.width)
+      }
+    },
+    [qrWidth],
+  )
+
+  const viewWidth = useMemo(() => {
+    if (qrWidth) {
+      return { width: qrWidth }
+    }
+    return {}
+  }, [qrWidth])
+
+  const logoMargin = useMemo(() => width * 0.07, [width])
+  const logoSize = useMemo(() => width * 0.15, [width])
+  const logoBorderRadius = useMemo(() => width * 0.4, [width])
+
+  useEffect(() => {
+    if (iconProps) {
+      const { Component, name, color } = iconProps
+
+      Component.getImageSource(name, logoSize, color).then(iconImage => {
+        setIconSource(iconImage)
+      })
+    }
+  }, [iconProps, logoSize])
+
+  return (
+    <View style={[viewWidth, containerViewStyle]} onLayout={onWidthChange}>
+      <QRCode
+        key={width}
+        value={value}
+        size={width}
+        logo={iconSource}
+        logoBackgroundColor={logoBackgroundColor}
+        logoSize={logoSize}
+        color={qrColor}
+        logoBorderRadius={logoBorderRadius}
+        quietZone={qrMargin}
+        logoMargin={logoMargin}
+        backgroundColor={qrBackgroundColor}
+      />
+    </View>
+  )
+}

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native'
+
 import { castStyle } from '../utils'
 
 export const testIDs = {
@@ -24,6 +25,7 @@ export const sharedColors = {
   subTitle: '#FBFBFB',
   tokenBackground: '#1E1E1E',
   black: '#000000',
+  qrColor: '#DBE3FF',
 }
 
 export const tokenColors = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,6 +4320,11 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dijkstrajs@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.2.tgz#2e48c0d3b825462afe75ab4ad5e829c8ece36257"
+  integrity sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -4413,6 +4418,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+encode-utf8@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
+  integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -8217,6 +8227,11 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -8326,7 +8341,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@*, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@*, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.0, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8374,6 +8389,16 @@ qr.js@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
   integrity sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==
+
+qrcode@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.1.tgz#0103f97317409f7bc91772ef30793a54cd59f0cb"
+  integrity sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==
+  dependencies:
+    dijkstrajs "^1.0.1"
+    encode-utf8 "^1.0.3"
+    pngjs "^5.0.0"
+    yargs "^15.3.1"
 
 query-string@6.13.5:
   version "6.13.5"
@@ -8613,6 +8638,14 @@ react-native-progress@^5.0.0:
   integrity sha512-KjnGIt3r9i5Kn2biOD9fXLJocf0bwxPRxOyAgXEnZTJQU2O+HyzgGFRCbM5h3izm9kKIkSc1txh8aGmMafCD9A==
   dependencies:
     prop-types "^15.7.2"
+
+react-native-qrcode-svg@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-qrcode-svg/-/react-native-qrcode-svg-6.2.0.tgz#62b62c5997ff23ba22544e289a6112a08f8ea306"
+  integrity sha512-rb2PgUwT8QpQyReVYNvzRY84AHsMh81354Tnkfp6MfqRbcdJURhnBWLBOO11pLMS6eXiwlq4SkcQxy88hRq+Dw==
+  dependencies:
+    prop-types "^15.8.0"
+    qrcode "^1.5.1"
 
 react-native-randombytes@^3.0.0:
   version "3.6.1"


### PR DESCRIPTION
Expected:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/39339295/220189443-07ab5665-7c34-4566-a200-34a7bd9a9069.png">


Actual:
<img width="328" alt="image" src="https://user-images.githubusercontent.com/39339295/220189368-c8020dd4-079e-4974-b06e-597d472351d7.png">

Notes: there is a transparent border radius margin in the expected image. For us to achieve that we need to import the image with the blue background, and then set the logoBackgroundColor to the same color as the view background color. The current implementation supports icons from the react native vector icons library, and it also supports an imageSource if required.
