### PR TITLE
Auto fix lint warning for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-    "cSpell.words": [
-        "hexlify"
-    ]
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
+    "source.fixAll.eslint": true,
+    "source.fixAll.tslint": true,
+    "source.fixAll.stylelint": true
+  },
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
It auto fixes all import and formatting warnings on save for VS Code in order to avoid CI errors.