### PR TITLE
fix: android profile header

### DIFF
--- a/src/navigation/profileNavigator/index.tsx
+++ b/src/navigation/profileNavigator/index.tsx
@@ -5,7 +5,7 @@ import {
 import Icon from 'react-native-vector-icons/FontAwesome5'
 import { useTranslation } from 'react-i18next'
 
-import { StyleSheet } from 'react-native'
+import { StyleSheet, Platform } from 'react-native'
 import { useEffect } from 'react'
 import { InjectedScreens } from 'src/core/Core'
 import { ProfileCreateScreen, ShareProfileScreen } from 'screens/index'
@@ -41,6 +41,7 @@ const screenOptionsWithHeader = (title: string): StackNavigationOptions => ({
     </Typography>
   ),
   headerStyle: headerStyles.headerStyle,
+  headerTitleAlign: 'center',
   headerShadowVisible: false,
 })
 
@@ -90,7 +91,7 @@ export const ProfileNavigator = ({
 
 export const headerStyles = StyleSheet.create({
   headerPosition: castStyle.view({
-    marginTop: -45,
+    marginTop: Platform.OS === 'ios' ? -45 : 0,
   }),
   headerStyle: castStyle.view({
     backgroundColor: sharedColors.primary,


### PR DESCRIPTION
This fixes broken profile navigation header on android

Android:
<img width="336" alt="Screenshot 2023-03-09 at 22 13 56" src="https://user-images.githubusercontent.com/85146/224225135-4de0d683-d8d5-4b6f-8b18-117d17e639b8.png">

IOS:
![image](https://user-images.githubusercontent.com/85146/224225080-59b5808f-6f0a-4572-9f65-a79df6ab5915.png)