### PR TITLE
US-1567 Added spinner instead of loading dots

### DIFF
--- a/src/components/loading/LoadingScreen.tsx
+++ b/src/components/loading/LoadingScreen.tsx
@@ -1,58 +1,26 @@
-import { useState, useEffect } from 'react'
 import { Modal, StyleSheet, View } from 'react-native'
 
+import { sharedColors, sharedStyles } from 'shared/constants'
+import { castStyle } from 'shared/utils'
+import { AppSpinner } from 'screens/spinner'
+
 export const LoadingScreen = () => {
-  const dotActive = {
-    ...styles.dot,
-    backgroundColor: '#d4e0ff',
-  }
-  const totalDots = 3
-  const [activeDot, setActiveDot] = useState<number>(0)
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setActiveDot(prev => (prev === totalDots ? 1 : prev + 1))
-    }, 450)
-
-    return () => clearInterval(timer)
-  }, [])
-
   return (
     <Modal animationType="none" transparent={true} visible={true}>
-      <View style={styles.container}>
-        <View style={styles.dotContainer}>
-          {Array.from({ length: 3 }).map((_, i) => (
-            <View
-              key={i}
-              style={activeDot === i + 1 ? dotActive : styles.dot}
-            />
-          ))}
-        </View>
+      <View
+        style={[
+          sharedStyles.flex,
+          sharedStyles.contentCenter,
+          styles.activityIndicatorViewStyle,
+        ]}>
+        <AppSpinner color="white" size={150} />
       </View>
     </Modal>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    height: '100%',
-    width: '100%',
-    backgroundColor: '#08003a',
-    display: 'flex',
-  },
-  dotContainer: {
-    flex: 1,
-    height: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'row',
-  },
-  dot: {
-    display: 'flex',
-    width: 18,
-    height: 18,
-    borderRadius: 9,
-    backgroundColor: '#5025ff',
-    marginHorizontal: 18,
-  },
+  activityIndicatorViewStyle: castStyle.view({
+    backgroundColor: sharedColors.secondary,
+  }),
 })


### PR DESCRIPTION
Refer to: https://rsklabs.atlassian.net/browse/US-1567

Expected:
![image](https://user-images.githubusercontent.com/39339295/229855668-16f53712-4562-4b2f-a6e7-65dcea7aa6b9.png)

Actual iOS:

https://user-images.githubusercontent.com/39339295/229854949-27d68776-e1b2-491c-a2d3-041194479f84.mp4


Actual android:


https://user-images.githubusercontent.com/39339295/229854001-07e13ba5-4ec5-4320-bc85-f8ddac16a87a.mp4

-
Note: Only the loading and the black background should be considered (this is a note that is coming from the ticket)
