### PR TITLE
fix: endless unlocking cycle

### DIFF
--- a/src/core/CoreGlobalErrorHandler.tsx
+++ b/src/core/CoreGlobalErrorHandler.tsx
@@ -1,25 +1,15 @@
 import { SafeAreaProvider } from 'react-native-safe-area-context'
-import { Platform } from 'react-native'
 
 import { GlobalErrorHandler } from '../components/GlobalErrorHandler'
 import ErrorBoundary from '../components/ErrorBoundary/ErrorBoundary'
 import { CoreWithStore } from './CoreWithStore'
-import { useAppState } from './hooks/useAppState'
 
 export const CoreGlobalErrorHandler = ({ CoreComponent = CoreWithStore }) => {
-  const { appState } = useAppState()
-
-  // Hide app when it's in background or inactive state
-  // For Android we must set FLAG_SECURE in MainActivity
-  // For iOS we must not render the CoreComponent (or build a custom screen)
-  const isNotActive = ['background', 'inactive'].includes(appState)
-  const hideApp = Platform.OS === 'ios' && isNotActive
-
   return (
     <GlobalErrorHandler>
       <ErrorBoundary>
         <SafeAreaProvider>
-          {hideApp ? null : <CoreComponent />}
+          <CoreComponent />
         </SafeAreaProvider>
       </ErrorBoundary>
     </GlobalErrorHandler>


### PR DESCRIPTION
After [this commit](https://github.com/rsksmart/swallet/commit/0860e2be4a33c92c5e262ddb39c103cc02ee016c) the app stucks in endless cycle of unlocking on IOS. @rodrigoncalves you need to come up with other solution as it is breaking one of the most important features and when you do, please, test that it does not break both Android and IOS