### PR TITLE
Go back should work on receive/send screen properly.

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -31,7 +31,12 @@ export const screenOptionsWithHeader = (
 ): HeaderProps => {
   return {
     headerShown: true,
-    headerLeft: () => (backButtonDisabled ? null : sharedHeaderLeftOptions()),
+    headerLeft: props =>
+      backButtonDisabled
+        ? null
+        : sharedHeaderLeftOptions(
+            'onPress' in props ? props.onPress : () => {},
+          ),
     headerTitle: props => (
       <>
         <Typography type={'h3'} style={props.style}>


### PR DESCRIPTION
After PR 574 the go back function default behavior was removed by mistake. This made the Receive/Send screen not go back when you tapped on the button. This PR fixes it.