### PR TITLE
refactor: show ExamplesScreen only if the mode is __DEV__

### DIFF
--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -112,13 +112,15 @@ export const SettingsScreen = ({
             </Typography>
           </AppTouchable>
         )}
-        <AppTouchable
-          width={'100%'}
-          accessibilityLabel={'example'}
-          style={styles.settingsItem}
-          onPress={goToExampleScreen}>
-          <Typography type={'h3'}>{t('settings_screen_examples')}</Typography>
-        </AppTouchable>
+        {__DEV__ && (
+          <AppTouchable
+            width={'100%'}
+            accessibilityLabel={'example'}
+            style={styles.settingsItem}
+            onPress={goToExampleScreen}>
+            <Typography type={'h3'}>{t('settings_screen_examples')}</Typography>
+          </AppTouchable>
+        )}
       </View>
       <View style={styles.bottomView}>
         <AppTouchable


### PR DESCRIPTION
@jessgusclark I've set `ExamplesScreen` visible only if the mode is `DEV`, tell me if we need to remove it completely. I can easily imagine a use for that in the nearest future