### PR TITLE
US-1673 pass array to stepper component and not object

### DIFF
--- a/src/navigation/profileNavigator/index.tsx
+++ b/src/navigation/profileNavigator/index.tsx
@@ -64,7 +64,7 @@ export const ProfileNavigator = ({
           top,
           t('profile_screen_title'),
           undefined,
-          { startColor, endColor },
+          [startColor, endColor],
         )}
       />
 
@@ -76,7 +76,7 @@ export const ProfileNavigator = ({
             top,
             t('username_registration_title'),
             undefined,
-            { startColor, endColor },
+            [startColor, endColor],
           )}
         />
       )}
@@ -89,7 +89,7 @@ export const ProfileNavigator = ({
             top,
             t('username_registration_title'),
             undefined,
-            { startColor, endColor },
+            [startColor, endColor],
           )}
         />
       )}


### PR DESCRIPTION
Passing the object was throwing an error because an object was being sent down instead of an array:

![image](https://github.com/rsksmart/swallet/assets/766679/a97b9bf9-623b-4b7b-a35b-bd9c044b0931)

Now, the debate between array and object can happen (my vote would be object) however, this PR is to fix the current build so we can get it out there. 