### PR TITLE
US-1679: Unable to import a wallet or create one on Android

### DIFF
--- a/src/components/address/AddressInput.test.tsx
+++ b/src/components/address/AddressInput.test.tsx
@@ -21,7 +21,7 @@ const WrappedAddressInput = ({
 }) => {
   const [address, setAddress] = useState('')
 
-  const onChangeText = (newAddress: string, isValid: boolean) => {
+  const onChangeText = (newAddress: string, _: string, isValid: boolean) => {
     handleChange(newAddress, isValid)
     setAddress(newAddress)
   }
@@ -29,7 +29,8 @@ const WrappedAddressInput = ({
   return (
     <AddressInput
       testID={testId}
-      initialValue={address}
+      inputName="address"
+      value={{ address }}
       onChangeAddress={onChangeText}
       chainId={31}
     />


### PR DESCRIPTION
For some reason the problem was caused because of errors in tests.