### PR TITLE
Avoid typing after the last digit when typing fast

### DIFF
--- a/src/screens/pinScreen/index.tsx
+++ b/src/screens/pinScreen/index.tsx
@@ -137,14 +137,17 @@ export const PinScreen = ({ navigation, route }: Props) => {
 
   const [title, setTitle] = useState<string>(initialPinTitle)
 
+  const resetPin = useCallback(() => {
+    setTimeout(() => setPIN(defaultPin), 100)
+  }, [])
+
   const handleNoPinStateCase = useCallback(
     (confirmPin: string | null, curPin: string) => {
       if (!confirmPin) {
         setSteps(noPinExistFirstStep)
-        setPIN(defaultPin)
         setConfirmPin(curPin)
         setTitle(t('pin_screen_confirm_pin_title'))
-        return
+        resetPin()
       } else {
         curPin === confirmPin
           ? (() => {
@@ -155,7 +158,7 @@ export const PinScreen = ({ navigation, route }: Props) => {
           : setHasError(true)
       }
     },
-    [t, dispatch],
+    [t, resetPin, dispatch],
   )
 
   const handleStatePinCase = useCallback(
@@ -259,8 +262,9 @@ export const PinScreen = ({ navigation, route }: Props) => {
         navigation.goBack()
       }, 1000)
     }
-    setPIN(defaultPin)
-  }, [PIN, isChangeRequested, isPinEqual, dispatch, navigation])
+
+    resetPin()
+  }, [isChangeRequested, isPinEqual, resetPin, dispatch, PIN, navigation])
 
   useEffect(() => {
     const hasLastDigit = PIN[PIN.length - 1]


### PR DESCRIPTION
Before:
[screencast-Genymotion-2023-06-02_01.54.49.851.webm](https://github.com/rsksmart/swallet/assets/4074139/05a39ab7-3250-49d2-8ff7-484abd42bf89)

After:
[screencast-Genymotion-2023-06-02_01.55.24.173.webm](https://github.com/rsksmart/swallet/assets/4074139/eabfbcee-36f7-43c6-ac1e-46ca7804b0b9)
