### PR TITLE
US-1670 Keyboard will hide when a transaction is sent.

### DIFF
--- a/src/screens/send/SendScreen.tsx
+++ b/src/screens/send/SendScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Alert, KeyboardAvoidingView, Platform } from 'react-native'
+import { Alert, Keyboard, KeyboardAvoidingView, Platform } from 'react-native'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -57,6 +57,7 @@ export const SendScreen = ({
 
   const onExecuteTransfer = useCallback(
     (token: TokenBalanceObject, amount: number, to: string) => {
+      Keyboard.dismiss()
       executePayment({
         token,
         amount,


### PR DESCRIPTION
This will fix the issue that the keyboard stays opened while the transaction request popup is opened.