### PR TITLE
US-1719 Added user-friendly error message. Fixed duration in RNS proc…

### DIFF
--- a/src/lib/rns/RnsProcessor.ts
+++ b/src/lib/rns/RnsProcessor.ts
@@ -134,25 +134,21 @@ export class RnsProcessor {
   }
   public register = async (domain: string) => {
     try {
-      const canReveal = await this.rskRegistrar.canReveal(
-        this.index[domain].hash,
-      )
+      const { hash, duration } = this.index[domain]
+      const canReveal = await this.rskRegistrar.canReveal(hash)
       if (await canReveal()) {
-        const duration = 1
         const price = await this.rskRegistrar.price(
           domain,
           BigNumber.from(duration),
         )
-
         const durationToRegister = BigNumber.from(duration)
-        const priceToRegister = BigNumber.from(price)
 
         const tx = await this.rskRegistrar.register(
           domain,
           this.wallet.smartWallet.smartWalletAddress,
           this.index[domain].secret,
           durationToRegister,
-          priceToRegister,
+          price,
         )
         this.onSetTransactionStatusChange?.({
           ...tx,

--- a/src/screens/rnsManager/PurchaseDomainScreen.tsx
+++ b/src/screens/rnsManager/PurchaseDomainScreen.tsx
@@ -103,10 +103,18 @@ export const PurchaseDomainScreen = ({
       }
     } catch (e) {
       if (typeof e === 'string' || e instanceof Error) {
-        setError(e.toString())
+        const message = e.toString()
+        if (
+          message.includes('balance too low') ||
+          message.includes('gasLimit exceeded')
+        ) {
+          setError(t('search_domain_error_funds_low'))
+        } else {
+          setError(e.toString())
+        }
       }
     }
-  }, [alias, dispatch, rnsProcessor, navigation])
+  }, [alias, dispatch, rnsProcessor, navigation, t])
 
   const onCancelDomainTap = useCallback(async () => {
     const domain = alias.split('.')[0]


### PR DESCRIPTION
…essor.

This fixes two things:

- The error message, instead of being too generic, it tells the user that his balance is too low.
- The price, there was a hardcoded 1 in the duration of the RNS process. The expected duration should come from the user (this.index...) and not hardcoded.

https://github.com/rsksmart/swallet/assets/39339295/e7a06456-e44b-4723-9b95-be7fa5275dd5

