### PR TITLE
US-1785 [Beta-testing iOs] Onboarding - Enabling FaceID from phone settings doesn't work.

### DIFF
--- a/src/storage/SecureStorage.ts
+++ b/src/storage/SecureStorage.ts
@@ -31,7 +31,7 @@ export const getKeys = async () => {
         accessControl:
           !supportedBiometry || !biometry
             ? ACCESS_CONTROL.DEVICE_PASSCODE
-            : ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+            : ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE,
       })
       if (!keys) {
         return null
@@ -70,7 +70,7 @@ export const saveKeys = async (keysValue: string) => {
         accessControl:
           !supportedBiometry || !biometry
             ? ACCESS_CONTROL.DEVICE_PASSCODE
-            : ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+            : ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE,
       })
     } else {
       saveKeysInMMKV(keysValue)


### PR DESCRIPTION
I've made it so there's a passcode fallback. If user did not have biometrics enabled when importing/creating wallet then he/she will have to always input password.