### PR TITLE
fix: AddressInput incorrectly sets address invalid

### DIFF
--- a/src/components/address/AddressInput.tsx
+++ b/src/components/address/AddressInput.tsx
@@ -19,6 +19,11 @@ import { Input, InputProps } from '../input'
 import { Avatar } from '../avatar'
 import { AppButton } from '../button'
 
+const bitcoinValidToAddressMessage = new Map([
+  [true, AddressValidationMessage.VALID],
+  [false, AddressValidationMessage.INVALID_ADDRESS],
+])
+
 export interface AddressInputProps extends Omit<InputProps, 'value'> {
   isBitcoin: boolean
   value: ContactWithAddressRequired
@@ -93,8 +98,10 @@ export const AddressInput = ({
 
       const parsedString = decodeString(inputText)
       const userInput = parsedString.address ? parsedString.address : inputText
-      const newValidationMessage = validateAddress(userInput, chainId)
       const isBitcoinValid = isBitcoinAddressValid(userInput)
+      const newValidationMessage = !isBitcoin
+        ? validateAddress(userInput, chainId)
+        : bitcoinValidToAddressMessage.get(isBitcoinValid)
 
       onChangeAddress(
         userInput,


### PR DESCRIPTION
This PR addresses the issue mentioned [here](https://github.com/rsksmart/swallet/pull/665). Now user should be able to send BTC. @jormelCoin make sure to check that other tokens can be sent too since I touched `AddressInput`.