### PR TITLE
[HOTFIX] Check if recentContacts exists

### DIFF
--- a/src/screens/contacts/index.tsx
+++ b/src/screens/contacts/index.tsx
@@ -87,7 +87,7 @@ export const ContactsScreen = ({ navigation }: ContactsListScreenProps) => {
 
   return (
     <View style={sharedStyles.screen}>
-      {recentContacts.length > 0 && (
+      {recentContacts && recentContacts.length > 0 && (
         <View style={styles.recentContacts}>
           <ScrollView horizontal>
             {recentContacts.map((c, i) => (


### PR DESCRIPTION
This line breaks the app if `recentContacts` does not exist. With new wallets it will always exist but when a user upgraded from the previous version to this one the variable didn't exist. This hotfix, already distributed, fixes that issue. 