### PR TITLE
US-1885 Fixed invalid precision for RBTC and other tokens

### DIFF
--- a/src/screens/send/transferTokens.ts
+++ b/src/screens/send/transferTokens.ts
@@ -3,6 +3,8 @@ import { BigNumber, utils } from 'ethers'
 import { ITokenWithBalance } from '@rsksmart/rif-wallet-services'
 import { RIFWallet } from '@rsksmart/rif-wallet-core'
 
+import { sanitizeMaxDecimalText } from 'lib/utils'
+
 import {
   OnSetCurrentTransactionFunction,
   OnSetErrorFunction,
@@ -46,10 +48,7 @@ export const transfer = async ({
   try {
     const decimals = await transferMethod.decimals()
     const tokenAmount = BigNumber.from(
-      utils.parseUnits(
-        amount.substring(0, amount.lastIndexOf('.') + 1 + decimals),
-        decimals,
-      ),
+      utils.parseUnits(sanitizeMaxDecimalText(amount, decimals), decimals),
     )
     const txPending = await transferMethod.transfer(
       to.toLowerCase(),


### PR DESCRIPTION
How to replicate issue in develop:

Try sending $1 RBTC

The math was converting the number to a 0.xxxxxxxxxxxxxx with more than 18 decimals, causing the issue. So I truncated the string to 18 decimals (or the decimals that the token supports)