### PR TITLE
US-1942:Passing user agent header to websocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@rsksmart/rif-wallet-bitcoin": "^1.2.0",
     "@rsksmart/rif-wallet-core": "^1.0.2",
     "@rsksmart/rif-wallet-eip681": "1.0.1",
-    "@rsksmart/rif-wallet-services": "^1.0.5",
+    "@rsksmart/rif-wallet-services": "^1.0.7",
     "@rsksmart/rif-wallet-token": "^1.0.1",
     "@rsksmart/rlogin-dpath": "^1.0.1",
     "@rsksmart/rns-resolver.js": "^1.0.1",

--- a/src/subscriptions/rifSockets.ts
+++ b/src/subscriptions/rifSockets.ts
@@ -6,6 +6,7 @@ import {
   RifWalletServicesSocket,
 } from '@rsksmart/rif-wallet-services'
 import { Options, setInternetCredentials } from 'react-native-keychain'
+import DeviceInfo from 'react-native-device-info'
 
 import { resetSocketState } from 'store/shared/actions/resetSocketState'
 import { AppDispatch } from 'store/index'
@@ -110,13 +111,15 @@ export const rifSockets = ({
       onSocketInit(payload, onChange),
     )
     rifWalletServicesSocket.on('change', onChange)
-    rifWalletServicesSocket.connect(wallet, fetcher).catch(err => {
-      if (err instanceof Error) {
-        setGlobalError(err.message)
-      } else {
-        setGlobalError('Error connecting to socket')
-      }
-    })
+    rifWalletServicesSocket
+      .connect(wallet, fetcher, { 'User-Agent': DeviceInfo.getUserAgentSync() })
+      .catch(err => {
+        if (err instanceof Error) {
+          setGlobalError(err.message)
+        } else {
+          setGlobalError('Error connecting to socket')
+        }
+      })
   }
 
   const disconnectSocket = rifWalletServicesSocket.disconnect

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,10 +2116,10 @@
   dependencies:
     "@rsksmart/rsk-utils" "^1.1.0"
 
-"@rsksmart/rif-wallet-services@^1.0.5":
-  version "1.0.5"
-  resolved "https://npm.pkg.github.com/download/@rsksmart/rif-wallet-services/1.0.5/dd97e829db5229df0b7c632e9b9e37c4c0118d96#dd97e829db5229df0b7c632e9b9e37c4c0118d96"
-  integrity sha512-RjCbqU4aj3Q2Hn5XhhxBqcQnKNgJY/dgGLton4d8k5B5xPDqCxOCvH6W3zyGRQXhqQz+Ax2pPl16L8GqsZwjUA==
+"@rsksmart/rif-wallet-services@^1.0.7":
+  version "1.0.7"
+  resolved "https://npm.pkg.github.com/download/@rsksmart/rif-wallet-services/1.0.7/097cc0812e126bed6649c0f00ed6cec4606e1860#097cc0812e126bed6649c0f00ed6cec4606e1860"
+  integrity sha512-2d+lh66VhWXfzM6atUF1vGmo32qIQirN3COQdAsiP4Jgt9OjTtfYR9SOqUfVAxPA+qp/YwLcCk0v6D4sl/YqrA==
   dependencies:
     "@ethersproject/contracts" "^5.7.0"
     "@rsksmart/rif-wallet-abi-enhancer" "*"


### PR DESCRIPTION
WAF blocks every call without the User-Agent header. 
<img width="330" alt="Screenshot 2023-09-21 at 12 31 05" src="https://github.com/rsksmart/rif-wallet/assets/96137983/9724befe-d4bb-43c0-844d-a8f7e3e18ed7">
