### PR TITLE
US-1965 The balance turns into NaN when loading wallet

### DIFF
--- a/src/redux/slices/balancesSlice/index.ts
+++ b/src/redux/slices/balancesSlice/index.ts
@@ -33,9 +33,13 @@ export const getBalance = (
   }
 
   let balance = balanceToDisplay(tokenBalance, token.decimals, 4)
+
+  // if the balance's decimals places are greater than 4
   if (Number(balance) === 0) {
     balance = balanceToDisplay(tokenBalance, token.decimals, 6)
   }
+
+  // if the balance's decimals places are greater than 6
   if (Number(balance) === 0) {
     balance = balanceToDisplay(tokenBalance, token.decimals, 8)
   }
@@ -68,7 +72,7 @@ export const addOrUpdateBalances = createAsyncThunk<
     if (bitcoin) {
       // add bitcoin balance to balances state
       const bitBalances: TokenBalanceObject[] = bitcoin.networksArr.map(b => {
-        const { balance, usdBalance } = getBalance(b, usdPrices.BTC?.price)
+        const { balance, usdBalance } = getBalance(b, usdPrices.BTC?.price ?? 0)
         return {
           name: b.networkName,
           contractAddress: b.contractAddress,


### PR DESCRIPTION
I've done the same for bitcoin as it's done for ERC20 token, set the price parameter to 0 if no `usdPrices.BTC` set.
https://github.com/rsksmart/rif-wallet/assets/47615361/e024a251-5971-4ff7-9c64-aaf1a4c1c1ff

I created [ticket](https://rsklabs.atlassian.net/jira/software/projects/US/boards/87/backlog?selectedIssue=US-1968) to solve the `usdPrices` issue.