### PR TITLE
US-1959: Other option for ios

### DIFF
--- a/src/screens/walletConnect/index.tsx
+++ b/src/screens/walletConnect/index.tsx
@@ -241,7 +241,7 @@ const styles = StyleSheet.create({
     flex: 4,
     alignSelf: 'center',
     width: '80%',
-    resizeMode: 'center',
+    resizeMode: 'contain',
   }),
   dappsList: castStyle.view({
     flex: 1,


### PR DESCRIPTION
There is an issue with resize mode 'center' for IOS(https://github.com/facebook/react-native/issues/28670). To verify this, we need to try on an IOS real device(release mode)