### PR TITLE
fix showing small balances

### DIFF
--- a/src/redux/slices/balancesSlice/index.ts
+++ b/src/redux/slices/balancesSlice/index.ts
@@ -19,17 +19,22 @@ export const getBalance = (
   token: ITokenWithBalance | BitcoinNetworkWithBIPRequest,
   price: number,
 ) => {
+  let tokenBalance = token.balance.toString()
   if ('satoshis' in token) {
-    const balanceBigNumber = convertBtcToSatoshi(token.balance.toString())
-    return {
-      balance: balanceToDisplay(balanceBigNumber.toString(), 8, 4),
-      usdBalance: convertBalance(balanceBigNumber, 8, price),
-    }
-  } else {
-    return {
-      balance: balanceToDisplay(token.balance, token.decimals, 4),
-      usdBalance: convertBalance(token.balance, token.decimals, price),
-    }
+    tokenBalance = convertBtcToSatoshi(tokenBalance).toString()
+  }
+
+  let balance = balanceToDisplay(tokenBalance, token.decimals, 4)
+  if (Number(balance) === 0) {
+    balance = balanceToDisplay(tokenBalance, token.decimals, 6)
+  }
+  if (Number(balance) === 0) {
+    balance = balanceToDisplay(tokenBalance, token.decimals, 8)
+  }
+
+  return {
+    balance,
+    usdBalance: convertBalance(tokenBalance, token.decimals, price),
   }
 }
 


### PR DESCRIPTION
This fixes the behavior where the transaction summary is not showing the user the right information.

Now it does.

Tx received
<img width="363" alt="image" src="https://github.com/rsksmart/rif-wallet/assets/39339295/bf672b31-008f-4e8a-8a26-1e28fa7d8afd">

Tx sent
<img width="378" alt="image" src="https://github.com/rsksmart/rif-wallet/assets/39339295/814c1923-6b03-498f-9ae5-29c2f645e28d">

User sent tx to himself:
<img width="387" alt="image" src="https://github.com/rsksmart/rif-wallet/assets/39339295/7279be0f-d450-44a8-b74b-ebad73b764c8">
