### PR TITLE
US-1730 Fixed bitcoin tx not being updated after a transaction was co…

### DIFF
--- a/src/screens/send/usePaymentExecutor.ts
+++ b/src/screens/send/usePaymentExecutor.ts
@@ -13,6 +13,7 @@ import {
   modifyTransaction,
   ApiTransactionWithExtras,
   ModifyTransaction,
+  fetchBitcoinTransactions,
 } from 'store/slices/transactionsSlice'
 import {
   fetchAddressToReturnFundsTo,
@@ -139,6 +140,10 @@ export const usePaymentExecutor = (
     addressUsed: string
   }) => {
     dispatch(addAddressToUsedBitcoinAddresses(addressUsed))
+    // Easy fix to avoid dispatching a lot: Fetch latest 3 bitcoin transactions after 3s of the tx being completed
+    setTimeout(() => {
+      dispatch(fetchBitcoinTransactions({ pageSize: 3 }))
+    }, 3000)
   }
 
   const executePayment = ({


### PR DESCRIPTION
…mpleted

Now when the user creates a bitcoin transaction, the setTimeout will dispatch a fetch after 3s to update the latest 3 transactions.

This is an easy fix to avoid doing a lot and it works perfectly.