### PR TITLE
Remove the word 'Test' from the iOS App name

### DIFF
--- a/ios/rifWallet/Info.plist
+++ b/ios/rifWallet/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>RIF Wallet Test</string>
+	<string>RIF Wallet</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
For the iOS review. 