### PR TITLE
US-1875 Added validation to make sure that when sending signTypedData…

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@rsksmart/rif-id-mnemonic": "^0.1.1",
     "@rsksmart/rif-relay-light-sdk": "^1.0.12",
     "@rsksmart/rif-wallet-abi-enhancer": "^1.0.8",
-    "@rsksmart/rif-wallet-adapters": "^1.0.0",
+    "@rsksmart/rif-wallet-adapters": "^1.0.1",
     "@rsksmart/rif-wallet-bitcoin": "^1.2.0",
     "@rsksmart/rif-wallet-core": "^1.0.2",
     "@rsksmart/rif-wallet-eip681": "1.0.1",

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -16,18 +16,8 @@ import { onRequest } from 'src/redux/slices/settingsSlice'
 import { getWalletSetting } from './config'
 import { SETTINGS } from './types'
 
-// function creates RIF Wallet instance
-// along with necessary confings
-const createRIFWallet = async (
-  chainId: 30 | 31,
-  wallet: Wallet,
-  onRequestFn: OnRequest,
-) => {
-  const jsonRpcProvider = new providers.StaticJsonRpcProvider(
-    getWalletSetting(SETTINGS.RPC_URL, chainTypesById[chainId]),
-  )
-
-  const rifRelayConfig: RifRelayConfig = {
+export const getRifRelayConfig = (chainId: 30 | 31): RifRelayConfig => {
+  return {
     smartWalletFactoryAddress: getWalletSetting(
       SETTINGS.SMART_WALLET_FACTORY_ADDRESS,
       chainTypesById[chainId],
@@ -45,6 +35,19 @@ const createRIFWallet = async (
       chainTypesById[chainId],
     ),
   }
+}
+// function creates RIF Wallet instance
+// along with necessary confings
+const createRIFWallet = async (
+  chainId: 30 | 31,
+  wallet: Wallet,
+  onRequestFn: OnRequest,
+) => {
+  const jsonRpcProvider = new providers.StaticJsonRpcProvider(
+    getWalletSetting(SETTINGS.RPC_URL, chainTypesById[chainId]),
+  )
+
+  const rifRelayConfig: RifRelayConfig = getRifRelayConfig(chainId)
 
   return await RIFWallet.create(
     wallet.connect(jsonRpcProvider),


### PR DESCRIPTION
… requests, if the address from/to is from relay then throw error

- [ ] Should be merged only when the library is deployed
- [ ] The logic should be verified by @jessgusclark to make sure that we're targeting the correct addresses. This because the ticket mentions relayWorkerAddress, which is not being exported by the rif-relay-light-sdk.