### PR TITLE
US-NO-REF Fixed WC repetition loop due to variable being refreshed ev…

### DIFF
--- a/src/screens/walletConnect/WalletConnect2Context.tsx
+++ b/src/screens/walletConnect/WalletConnect2Context.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useState,
+  useMemo,
 } from 'react'
 import { getSdkError, parseUri } from '@walletconnect/utils'
 import Web3Wallet, { Web3WalletTypes } from '@walletconnect/web3wallet'
@@ -118,7 +119,7 @@ export const WalletConnect2Provider = ({
   >(undefined)
   const [error, setError] = useState<WalletConnect2ContextArguments['error']>()
 
-  const rifRelayConfig = getRifRelayConfig(chainId)
+  const rifRelayConfig = useMemo(() => getRifRelayConfig(chainId), [chainId])
 
   const onSessionProposal = async (
     proposal: Web3WalletTypes.SessionProposal,
@@ -314,7 +315,8 @@ export const WalletConnect2Provider = ({
     if (wallet) {
       onContextFirstLoad().catch(console.log)
     }
-  }, [onContextFirstLoad, wallet])
+  }, [wallet, onContextFirstLoad])
+
   return (
     <WalletConnect2Context.Provider
       value={{


### PR DESCRIPTION
The WC useEffect was running over and over because rifRelayConfig was re-rendering everytime. I've wrapped it in a useMemo to make sure that we don't recreate the variable when the chainId is the same.