### PR TITLE
US-2048 User should not be able to copy their mnemonic so that they keep it private and secure

### DIFF
--- a/src/components/mnemonic/index.tsx
+++ b/src/components/mnemonic/index.tsx
@@ -1,8 +1,6 @@
-import Clipboard from '@react-native-community/clipboard'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert, StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
-import Icon from 'react-native-vector-icons/FontAwesome5'
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
 
 import { sharedColors, sharedStyles } from 'shared/constants'
 import { castStyle } from 'shared/utils'


### PR DESCRIPTION

https://github.com/rsksmart/rif-wallet/assets/47615361/9188f7fa-d9e0-49d0-b8fc-2152b4296bf3

Since we're using same exact component everywhere we need to see mnemonic, this change makes sure user will not be able to copy mnemonic.