### PR TITLE
Handle RIF Relay Estimation Error

### DIFF
--- a/src/ux/requestsModal/ReviewRelayTransaction/ReviewTransactionContainer.tsx
+++ b/src/ux/requestsModal/ReviewRelayTransaction/ReviewTransactionContainer.tsx
@@ -126,8 +126,12 @@ export const ReviewTransactionContainer = ({
     wallet.rifRelaySdk
       .estimateTransactionCost(txRequest, feeContract)
       .then(setTxCostInRif)
-      .catch(err => errorHandler(err))
-  }, [txRequest, wallet.rifRelaySdk, feeContract])
+      .catch(err => {
+        console.log('Server Error', err)
+        request.reject('There is an error connecting to the RIF Relay Server.')
+        onCancel()
+      })
+  }, [txRequest, wallet.rifRelaySdk, feeContract, request, onCancel])
 
   const confirmTransaction = useCallback(async () => {
     dispatch(addRecentContact(to))


### PR DESCRIPTION
If the rif relay server is down, reject the transaction with the message unable to connect and call the onCancel() screen.

This fixes the issue of the spinning wheel.