### PR TITLE
Revert "Build(deps): Bump react-native-mmkv from 2.5.1 to 2.11.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-native-jdenticon": "^0.0.3",
     "react-native-keychain": "^8.1.1",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-mmkv": "^2.11.0",
+    "react-native-mmkv": "^2.4.3",
     "react-native-modal": "^13.0.1",
     "react-native-progress": "^5.0.0",
     "react-native-qrcode-svg": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9370,10 +9370,10 @@ react-native-mmkv-flipper-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-mmkv-flipper-plugin/-/react-native-mmkv-flipper-plugin-1.0.0.tgz#f87f747d8cea51d2b12a1e711287feff5f212788"
   integrity sha512-e3owMIBzXez45Wz8Ac84Vf1FmfwMXFVUpf/gCDWDLq19w7iCipVezQjlZo8ISVza8aQf1G4ggaK/r+qqtGmRlg==
 
-react-native-mmkv@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.11.0.tgz#51b9985f6a5c09fe9c16d8c1861cc2901856ace1"
-  integrity sha512-28PdUHjZJmAw3q+8zJDAAdohnZMpDC7WgRUJxACOMkcmJeqS3u5cKS/lSq2bhf1CvaeIiHYHUWiyatUjMRCDQQ==
+react-native-mmkv@^2.4.3:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.5.1.tgz#29fc462077fab16a5e1b79570fbf8acaac9d87b4"
+  integrity sha512-5eQu25z3H6zf6w0NkJoTuFEFrbOu6luZxZ6+rK1W+XwY/rjPSFZFQPVtMaz3im90RbILFXXM/KrFGZrpaJJRoQ==
 
 react-native-modal@^13.0.1:
   version "13.0.1"


### PR DESCRIPTION
Reverts rsksmart/rif-wallet#859

Reverting bumping this package as our current version of React Native doesn't support this version of MMKV. We need to bump to RN73 first.

Source: https://github.com/mrousavy/react-native-mmkv/issues/540