### PR TITLE
Fix two issues regarding Android Build and Dev

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -213,11 +213,21 @@ android {
     signingConfigs {
         release {
             Properties properties = new Properties()
-            properties.load(project.rootProject.file('local.properties').newDataInputStream())
-            storeFile file(properties.getProperty('storeFile'))
-            keyAlias properties.getProperty('keyAlias')
-            storePassword properties.getProperty('storePassword')
-            keyPassword properties.getProperty('keyPassword')
+            def localPropertiesFile = project.rootProject.file('local.properties')
+
+            if (localPropertiesFile.exists()) {
+                properties.load(localPropertiesFile.newDataInputStream())
+                storeFile file(properties.getProperty('storeFile'))
+                keyAlias properties.getProperty('keyAlias')
+                storePassword properties.getProperty('storePassword')
+                keyPassword properties.getProperty('keyPassword')
+            } else {
+                // file did not exist:
+                storeFile file('debug.keystore')
+                storePassword 'android'
+                keyAlias 'androiddebugkey'
+                keyPassword 'android'
+            }
         }
         debug {
             storeFile file('debug.keystore')

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-native-jdenticon": "^0.0.3",
     "react-native-keychain": "^8.1.1",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-mmkv": "^2.11.0",
+    "react-native-mmkv": "^2.4.3",
     "react-native-modal": "^13.0.1",
     "react-native-progress": "^5.0.0",
     "react-native-qrcode-svg": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-native-jdenticon": "^0.0.3",
     "react-native-keychain": "^8.1.1",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-mmkv": "^2.4.3",
+    "react-native-mmkv": "2.4.3",
     "react-native-modal": "^13.0.1",
     "react-native-progress": "^5.0.0",
     "react-native-qrcode-svg": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9370,7 +9370,7 @@ react-native-mmkv-flipper-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-mmkv-flipper-plugin/-/react-native-mmkv-flipper-plugin-1.0.0.tgz#f87f747d8cea51d2b12a1e711287feff5f212788"
   integrity sha512-e3owMIBzXez45Wz8Ac84Vf1FmfwMXFVUpf/gCDWDLq19w7iCipVezQjlZo8ISVza8aQf1G4ggaK/r+qqtGmRlg==
 
-react-native-mmkv@^2.11.0:
+react-native-mmkv@^2.4.3:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.11.0.tgz#51b9985f6a5c09fe9c16d8c1861cc2901856ace1"
   integrity sha512-28PdUHjZJmAw3q+8zJDAAdohnZMpDC7WgRUJxACOMkcmJeqS3u5cKS/lSq2bhf1CvaeIiHYHUWiyatUjMRCDQQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9370,10 +9370,10 @@ react-native-mmkv-flipper-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-mmkv-flipper-plugin/-/react-native-mmkv-flipper-plugin-1.0.0.tgz#f87f747d8cea51d2b12a1e711287feff5f212788"
   integrity sha512-e3owMIBzXez45Wz8Ac84Vf1FmfwMXFVUpf/gCDWDLq19w7iCipVezQjlZo8ISVza8aQf1G4ggaK/r+qqtGmRlg==
 
-react-native-mmkv@^2.4.3:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.11.0.tgz#51b9985f6a5c09fe9c16d8c1861cc2901856ace1"
-  integrity sha512-28PdUHjZJmAw3q+8zJDAAdohnZMpDC7WgRUJxACOMkcmJeqS3u5cKS/lSq2bhf1CvaeIiHYHUWiyatUjMRCDQQ==
+react-native-mmkv@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.4.3.tgz#6bb4c2d5e328513da11faab1371d056a189adbd0"
+  integrity sha512-0hYNOTbsjJ5j5cpX+qjwReGIxuYE9MWRsyPQ72fTOvzmEjYXCF4Wr2VQoqx8R6W1/Uinekvln7dGvJ4RExmHhQ==
 
 react-native-modal@^13.0.1:
   version "13.0.1"


### PR DESCRIPTION
This fixes two issues caused today for the Android build.

1. We revert the bump in MMKV which causes conflicts with our current version of RN. We will update RN first then MMKV.
2. Checks if the local.properties file exists first before assigning values. If the file does not exist then it uses the defaults under debug