### PR TITLE
Add RIF Faucet as a known address in testnet.

### DIFF
--- a/src/redux/slices/contactsSlice/constants.ts
+++ b/src/redux/slices/contactsSlice/constants.ts
@@ -8,6 +8,12 @@ export const testnetContacts: Record<string, Contact> = {
     displayAddress: TESTNET.rBTCFaucet,
     isEditable: false,
   },
+  [TESTNET.rifFaucet]: {
+    address: TESTNET.rifFaucet,
+    name: 'RIF Faucet',
+    displayAddress: TESTNET.rifFaucet,
+    isEditable: false,
+  },
   [TESTNET.fifsAddrRegistrarAddress]: {
     address: TESTNET.fifsAddrRegistrarAddress,
     name: 'RNS Manager',

--- a/src/screens/rnsManager/addresses.json
+++ b/src/screens/rnsManager/addresses.json
@@ -5,7 +5,8 @@
     "rifTokenAddress": "0x19f64674d8a5b4e652319f5e239efd3bc969a1fe",
     "rnsRegistryAddress": "0x7d284aaac6e925aad802a53c0c69efe3764597b8",
     "rifWalletDeployment": "0x0000000000000000000000000000000000000000",
-    "rBTCFaucet": "0x88250f772101179a4ecfaa4b92a983676a3ce445"
+    "rBTCFaucet": "0x88250f772101179a4ecfaa4b92a983676a3ce445",
+    "rifFaucet": "0x248b320687ebf655f9ee7f62f0388c79fbb7b2f4"
   },
   "MAINNET": {
     "rskOwnerAddress": "0x45d3e4fb311982a06ba52359d44cb4f5980e0ef1",


### PR DESCRIPTION
This should work for both the EOA and Relay versions as the address is the same.

Example:
![Screenshot 2024-01-26 at 2 54 20 PM](https://github.com/rsksmart/rif-wallet/assets/766679/3f4ec9f3-cc05-477e-9924-cae2b8c11fd7)

Merging into `us-2005`