### PR TITLE
Fix Android Build Github Action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,8 +1,9 @@
 name: Android Build SDK
 
 on:
-  release:
-    types: [released]
+  pull_request
+#  release:
+#    types: [released]
 
 jobs:
   install-and-test:
@@ -37,7 +38,8 @@ jobs:
 
       - name: Build Android Release
         run: |
-          cd android && ./gradlew app:assembleRelease
+          cd android
+          ./gradlew app:assembleRelease
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,9 +1,8 @@
 name: Android Build SDK
 
 on:
-  pull_request
-#  release:
-#    types: [released]
+  release:
+    types: [released]
 
 jobs:
   install-and-test:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: yarn
@@ -30,10 +30,10 @@ jobs:
     steps: 
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 20.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: yarn
@@ -30,10 +30,10 @@ jobs:
     steps: 
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,12 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up NPM authentication
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_KEY }}" >> ~/.npmrc
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
 
       - name: Install dependencies
-        run: |
-          yarn
+        run: yarn
 
       - name: Test and Lint
         run: |
@@ -29,12 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v3
-      - name: Set up NPM authentication
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_KEY }}" >> ~/.npmrc
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
 
       - name: Install dependencies
-        run: |
-          yarn
+        run: yarn
 
       - name: Build Android Release
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
+    - uses: actions/checkout@v3
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
-    - name: Set up NPM authentication
-      run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_KEY }}" >> ~/.npmrc
-    - run: yarn
-    - run: yarn ganache &
-    - run: yarn test
-    - run: yarn lint
+        node-version: 20.x
+
+    - name: Install dependencies
+      run: yarn
+
+    - name: Test and Lint
+      run: |
+        yarn ganache &
+        yarn test
+        yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 20.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 20.x
+        node-version: 16.x
 
     - name: Install dependencies
       run: yarn


### PR DESCRIPTION
Adds back in the android build on new release.

- Sets node version
- Removes Github Packages NPM authentication
- Formats CI better