### PR TITLE
US-2121 Remove RDOC as a default token in mainnet and testnet

### DIFF
--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -39,7 +39,7 @@ export const getRnsResolver = (
 
 const defaultMainnetTokens: ITokenWithoutLogo[] = Object.keys(mainnetContracts)
   .filter(address =>
-    ['RDOC', 'RIF', 'USDRIF'].includes(mainnetContracts[address].symbol),
+    ['RIF', 'USDRIF'].includes(mainnetContracts[address].symbol),
   )
   .map(address => {
     const { decimals, name, symbol } = mainnetContracts[address]
@@ -54,7 +54,7 @@ const defaultMainnetTokens: ITokenWithoutLogo[] = Object.keys(mainnetContracts)
   })
 const defaultTestnetTokens: ITokenWithoutLogo[] = Object.keys(testnetContracts)
   .filter(address =>
-    ['RDOC', 'tRIF', 'USDRIF'].includes(testnetContracts[address].symbol),
+    ['tRIF', 'USDRIF'].includes(testnetContracts[address].symbol),
   )
   .map(address => {
     const { decimals, name, symbol } = testnetContracts[address]


### PR DESCRIPTION
I cannot provide screenshot because of the error [mentioned](https://iov-labs.slack.com/archives/C05DCDGN2UT/p1706689448320679) in Slack