### PR TITLE
Add a version identifier to the settings menu

### DIFF
--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -153,31 +153,39 @@ export const SettingsScreen = ({
         </Typography>
       </AppTouchable>
       <View style={styles.bottomView}>
-        <Typography type={'body1'} color={sharedColors.labelLight}>
-          {t('settings_screen_version')} {version}-
-          {Config.USE_RELAY ? 'relay' : 'eoa'}
-        </Typography>
+        <View style={styles.settingsItem}>
+          <Typography type={'h4'} color={sharedColors.labelLight}>
+            {t('settings_screen_version')} {version}-
+            {Config.USE_RELAY ? 'relay' : 'eoa'}
+          </Typography>
+        </View>
 
-        <Typography type={'h4'} color={sharedColors.labelLight}>
-          {t('settings_screen_smart_wallet_factory')}
-        </Typography>
-        <Typography type={'h5'} color={sharedColors.labelLight}>
-          {smartWalletFactoryAddress}
-        </Typography>
+        <View style={styles.settingsItem}>
+          <Typography type={'h4'} color={sharedColors.labelLight}>
+            {t('settings_screen_smart_wallet_factory')}
+          </Typography>
+          <Typography type={'h5'} color={sharedColors.labelLight}>
+            {smartWalletFactoryAddress}
+          </Typography>
+        </View>
 
-        <Typography type={'h4'} color={sharedColors.labelLight}>
-          {t('settings_screen_rpc_url')}
-        </Typography>
-        <Typography type={'h5'} color={sharedColors.labelLight}>
-          {rpcUrl}
-        </Typography>
+        <View style={styles.settingsItem}>
+          <Typography type={'h4'} color={sharedColors.labelLight}>
+            {t('settings_screen_rpc_url')}
+          </Typography>
+          <Typography type={'h5'} color={sharedColors.labelLight}>
+            {rpcUrl}
+          </Typography>
+        </View>
 
-        <Typography type={'h4'} color={sharedColors.labelLight}>
-          {t('settings_screen_backend_url')}
-        </Typography>
-        <Typography type={'h5'} color={sharedColors.labelLight}>
-          {walletServiceUrl}
-        </Typography>
+        <View style={styles.settingsItem}>
+          <Typography type={'h4'} color={sharedColors.labelLight}>
+            {t('settings_screen_backend_url')}
+          </Typography>
+          <Typography type={'h5'} color={sharedColors.labelLight}>
+            {walletServiceUrl}
+          </Typography>
+        </View>
       </View>
     </ScrollView>
   )

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -2,6 +2,7 @@ import { version } from 'package.json'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, ScrollView, StyleSheet, View } from 'react-native'
+import Config from 'react-native-config'
 
 import { AppTouchable, Typography } from 'components/index'
 import { getWalletSetting } from 'core/config'
@@ -152,60 +153,31 @@ export const SettingsScreen = ({
         </Typography>
       </AppTouchable>
       <View style={styles.bottomView}>
-        <AppTouchable
-          width={'100%'}
-          accessibilityLabel="version"
-          style={styles.footerItem}
-          onPress={goToWalletBackup}>
-          <Typography type={'body1'} color={sharedColors.labelLight}>
-            {t('settings_screen_version')} {version}
-          </Typography>
-        </AppTouchable>
+        <Typography type={'body1'} color={sharedColors.labelLight}>
+          {t('settings_screen_version')} {version}-
+          {Config.USE_RELAY ? 'relay' : 'eoa'}
+        </Typography>
 
-        <AppTouchable
-          width={'100%'}
-          accessibilityLabel="Smart Wallet Factory"
-          style={styles.footerItem}
-          onPress={goToWalletBackup}>
-          <>
-            <Typography type={'h4'} color={sharedColors.labelLight}>
-              {t('settings_screen_smart_wallet_factory')}
-            </Typography>
-            <Typography type={'h5'} color={sharedColors.labelLight}>
-              {smartWalletFactoryAddress}
-            </Typography>
-          </>
-        </AppTouchable>
+        <Typography type={'h4'} color={sharedColors.labelLight}>
+          {t('settings_screen_smart_wallet_factory')}
+        </Typography>
+        <Typography type={'h5'} color={sharedColors.labelLight}>
+          {smartWalletFactoryAddress}
+        </Typography>
 
-        <AppTouchable
-          width={'100%'}
-          accessibilityLabel="security"
-          style={styles.footerItem}
-          onPress={goToWalletBackup}>
-          <>
-            <Typography type={'h4'} color={sharedColors.labelLight}>
-              {t('settings_screen_rpc_url')}
-            </Typography>
-            <Typography type={'h5'} color={sharedColors.labelLight}>
-              {rpcUrl}
-            </Typography>
-          </>
-        </AppTouchable>
+        <Typography type={'h4'} color={sharedColors.labelLight}>
+          {t('settings_screen_rpc_url')}
+        </Typography>
+        <Typography type={'h5'} color={sharedColors.labelLight}>
+          {rpcUrl}
+        </Typography>
 
-        <AppTouchable
-          width={'100%'}
-          accessibilityLabel="Backend URL"
-          style={styles.footerItem}
-          onPress={goToWalletBackup}>
-          <>
-            <Typography type={'h4'} color={sharedColors.labelLight}>
-              {t('settings_screen_backend_url')}
-            </Typography>
-            <Typography type={'h5'} color={sharedColors.labelLight}>
-              {walletServiceUrl}
-            </Typography>
-          </>
-        </AppTouchable>
+        <Typography type={'h4'} color={sharedColors.labelLight}>
+          {t('settings_screen_backend_url')}
+        </Typography>
+        <Typography type={'h5'} color={sharedColors.labelLight}>
+          {walletServiceUrl}
+        </Typography>
       </View>
     </ScrollView>
   )


### PR DESCRIPTION
This also removes the <AppTouchable> that was linking to the mnemonic screen. I'm not sure why that was in there and why it wasn't caught. 

![Screenshot 2024-02-02 at 4 09 25 PM](https://github.com/rsksmart/rif-wallet/assets/766679/30d6683b-7a38-4ff3-b7b4-5130aa459fee)
