### PR TITLE
refactor: single source chainId type

### DIFF
--- a/src/components/accounts/AccountBox.tsx
+++ b/src/components/accounts/AccountBox.tsx
@@ -6,6 +6,8 @@ import { StyleSheet, TextInput, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import Icon from 'react-native-vector-icons/FontAwesome'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import {
   AppButton,
   AppButtonBackgroundVarietyEnum,
@@ -23,7 +25,6 @@ import { WalletIsDeployed } from 'store/slices/settingsSlice/types'
 import { selectAccounts } from 'store/slices/accountsSlice/selector'
 import { AccountPayload } from 'store/slices/accountsSlice/types'
 import { useAppDispatch, useAppSelector } from 'store/storeUtils'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 import { DeleteWalletModal } from 'components/modal/deleteWalletModal'
 
 import { CheckIcon } from '../icons/CheckIcon'
@@ -31,7 +32,7 @@ import { CheckIcon } from '../icons/CheckIcon'
 interface AccountBoxProps {
   address: string
   smartWalletAddress: string | null
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   walletIsDeployed: WalletIsDeployed
   publicKeys: PublicKeyItemType[]
   id?: number

--- a/src/components/address/AddressInput.tsx
+++ b/src/components/address/AddressInput.tsx
@@ -6,14 +6,11 @@ import { useTranslation } from 'react-i18next'
 import { isBitcoinAddressValid } from '@rsksmart/rif-wallet-bitcoin'
 import { Network } from 'bitcoin-address-validation'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { getRnsResolver } from 'core/setup'
 import { sharedColors } from 'shared/constants'
 import { Contact, ContactWithAddressRequired } from 'shared/types'
-import {
-  ChainTypeEnum,
-  ChainTypesByIdType,
-  chainTypesById,
-} from 'shared/constants/chainConstants'
 import { castStyle } from 'shared/utils'
 import { ContactCard } from 'screens/contacts/components'
 import { ProposedContact } from 'screens/send/TransactionForm'
@@ -37,7 +34,7 @@ export interface AddressInputProps extends Omit<InputProps, 'value'> {
     newDisplayValue: string,
     isValid: boolean,
   ) => void
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   contactList?: Contact[]
   onSetLoadingRNS?: (isLoading: boolean) => void
   searchContacts?: (textString: string) => void
@@ -241,8 +238,7 @@ export const AddressInput = ({
       let validationMessage: AddressValidationMessage
       if (isBitcoin) {
         if (isBitcoinValid) {
-          const isMainnet = chainTypesById[chainId] === ChainTypeEnum.MAINNET
-          const network = isMainnet ? Network.mainnet : Network.testnet
+          const network = chainId === 30 ? Network.mainnet : Network.testnet
           const isNetworkValid = isBitcoinAddressValid(userInput, network)
           validationMessage = isNetworkValid
             ? AddressValidationMessage.VALID

--- a/src/components/address/lib.ts
+++ b/src/components/address/lib.ts
@@ -5,8 +5,7 @@ import {
 } from '@rsksmart/rsk-utils'
 
 import { shortAddress } from 'lib/utils'
-
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
+import { ChainID } from 'lib/eoaWallet'
 
 export enum AddressValidationMessage {
   INVALID_ADDRESS = 'Invalid address',
@@ -64,7 +63,7 @@ export const isMyAddress = (
 
 export const getAddressDisplayText = (
   inputAddress: string,
-  chainId: ChainTypesByIdType,
+  chainId: ChainID,
 ) => {
   const checksumAddress = toChecksumAddress(inputAddress, chainId)
   const displayAddress = shortAddress(checksumAddress)

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -4,10 +4,9 @@ import config from 'config.json'
 import ReactNativeConfig from 'react-native-config'
 import { constants } from 'ethers'
 
-import {
-  ChainTypeEnum,
-  ChainTypesByIdType,
-} from 'shared/constants/chainConstants'
+import { ChainID } from 'lib/eoaWallet'
+
+import { chainTypesById } from 'shared/constants/chainConstants'
 import { SETTINGS } from 'core/types'
 import { TokenSymbol } from 'screens/home/TokenImage'
 
@@ -19,9 +18,9 @@ import { TokenSymbol } from 'screens/home/TokenImage'
  */
 export const getWalletSetting = (
   setting: SETTINGS,
-  chainType: ChainTypeEnum,
+  chainId: ChainID,
 ): string => {
-  const key = `${setting}_${chainType}`
+  const key = `${setting}_${chainTypesById[chainId]}`
   if (key in config) {
     return config[key as keyof typeof config]
   }
@@ -38,10 +37,7 @@ export const getWalletSetting = (
  */
 export const getEnvSetting = (setting: SETTINGS) => ReactNativeConfig[setting]
 
-export const getTokenAddress = (
-  symbol: TokenSymbol,
-  chainId: ChainTypesByIdType,
-) => {
+export const getTokenAddress = (symbol: TokenSymbol, chainId: ChainID) => {
   const contracts = chainId === 31 ? testnetContracts : mainnetContracts
 
   const result = Object.keys(contracts).find(

--- a/src/core/hooks/bitcoin/initializeBitcoin.ts
+++ b/src/core/hooks/bitcoin/initializeBitcoin.ts
@@ -7,6 +7,8 @@ import {
 } from '@rsksmart/rif-wallet-bitcoin'
 import { RifWalletServicesFetcher } from '@rsksmart/rif-wallet-services'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import {
   BitcoinNetworkStore,
   StoredBitcoinNetworks,
@@ -16,29 +18,21 @@ import { bitcoinMainnet, bitcoinTestnet } from 'shared/constants'
 import { onRequest } from 'store/slices/settingsSlice'
 import { AppDispatch } from 'store/index'
 import { Bitcoin } from 'store/slices/settingsSlice/types'
-import {
-  ChainTypeEnum,
-  chainTypesById,
-  ChainTypesByIdType,
-} from 'shared/constants/chainConstants'
 
 const NETWORKS_INITIAL_STATE: Bitcoin = {
   networksArr: [],
   networksMap: {},
 }
 
-const onNoNetworksPresent = (chainId: ChainTypesByIdType) => {
-  const bitcoinNetwork =
-    chainTypesById[chainId] === ChainTypeEnum.MAINNET
-      ? bitcoinMainnet
-      : bitcoinTestnet
+const onNoNetworksPresent = (chainId: ChainID) => {
+  const bitcoinNetwork = chainId === 30 ? bitcoinMainnet : bitcoinTestnet
 
   BitcoinNetworkStore.addNewNetwork(bitcoinNetwork.name, bitcoinNetwork.bips)
 
   return BitcoinNetworkStore.getStoredNetworks()
 }
 
-const BITCOIN_CHAINID_MAP: Record<ChainTypesByIdType, string> = {
+const BITCOIN_CHAINID_MAP: Record<ChainID, string> = {
   30: bitcoinMainnet.name,
   31: bitcoinTestnet.name,
 }
@@ -56,7 +50,7 @@ export const initializeBitcoin = (
   mnemonic: string,
   dispatch: AppDispatch,
   fetcher: RifWalletServicesFetcher,
-  chainId: ChainTypesByIdType,
+  chainId: ChainID,
 ) => {
   // Return Object which contains both array and map
   const networksObj = NETWORKS_INITIAL_STATE

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -15,10 +15,7 @@ import { getWalletSetting } from './config'
 
 export const createPublicAxios = (chainId: ChainID) =>
   axios.create({
-    baseURL: getWalletSetting(
-      SETTINGS.RIF_WALLET_SERVICE_URL,
-      chainTypesById[chainId],
-    ),
+    baseURL: getWalletSetting(SETTINGS.RIF_WALLET_SERVICE_URL, chainId),
   })
 
 export const abiEnhancer = new AbiEnhancer()

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -4,19 +4,16 @@ import mainnetContracts from '@rsksmart/rsk-contract-metadata'
 import testnetContracts from '@rsksmart/rsk-testnet-contract-metadata'
 import axios from 'axios'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { SETTINGS } from 'core/types'
 import { MAINNET, TESTNET } from 'screens/rnsManager/addresses.json'
-import {
-  ChainTypeEnum,
-  ChainTypesByIdType,
-  chainTypesById,
-} from 'shared/constants/chainConstants'
 import { ITokenWithoutLogo } from 'store/slices/balancesSlice/types'
 import { Wallet } from 'shared/wallet'
 
 import { getWalletSetting } from './config'
 
-export const createPublicAxios = (chainId: ChainTypesByIdType) =>
+export const createPublicAxios = (chainId: ChainID) =>
   axios.create({
     baseURL: getWalletSetting(
       SETTINGS.RIF_WALLET_SERVICE_URL,
@@ -26,11 +23,10 @@ export const createPublicAxios = (chainId: ChainTypesByIdType) =>
 
 export const abiEnhancer = new AbiEnhancer()
 
-export const getRnsResolver = (chainId: ChainTypesByIdType, wallet: Wallet) => {
-  const isMainnet = chainTypesById[chainId] === ChainTypeEnum.MAINNET
-  const rnsRegistryAddress = isMainnet
-    ? MAINNET.rnsRegistryAddress
-    : TESTNET.rnsRegistryAddress
+export const getRnsResolver = (chainId: ChainID, wallet: Wallet) => {
+  const rnsRegistryAddress =
+    chainId === 30 ? MAINNET.rnsRegistryAddress : TESTNET.rnsRegistryAddress
+
   return new AddrResolver(rnsRegistryAddress, wallet)
 }
 
@@ -64,8 +60,6 @@ const defaultTestnetTokens: ITokenWithoutLogo[] = Object.keys(testnetContracts)
       usdBalance: 0,
     }
   })
-export const getDefaultTokens = (chainId: ChainTypesByIdType) => {
-  return chainTypesById[chainId] === ChainTypeEnum.MAINNET
-    ? defaultMainnetTokens
-    : defaultTestnetTokens
+export const getDefaultTokens = (chainId: ChainID) => {
+  return chainId === 30 ? defaultMainnetTokens : defaultTestnetTokens
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,8 @@ import moment from 'moment'
 import { abiEnhancer } from 'core/setup'
 import { ApiTransactionWithExtras } from 'src/redux/slices/transactionsSlice'
 
+import { ChainID } from './eoaWallet'
+
 export function shortAddress(address: string, amount = 4): string {
   if (!address) {
     return ''
@@ -187,7 +189,7 @@ export const removeLeadingZeros = (value: string) => {
  */
 export const createPendingTxFromTxResponse = async (
   txResponse: TransactionResponse,
-  { chainId, from, to }: { chainId: number; from: string; to: string },
+  { chainId, from, to }: { chainId: ChainID; from: string; to: string },
 ) => {
   try {
     const enhancedTx = await abiEnhancer.enhance(chainId, {

--- a/src/redux/slices/settingsSlice/index.ts
+++ b/src/redux/slices/settingsSlice/index.ts
@@ -59,41 +59,38 @@ export const getRifRelayConfig = (chainId: 30 | 31): RifRelayConfig => {
   return {
     smartWalletFactoryAddress: getWalletSetting(
       SETTINGS.SMART_WALLET_FACTORY_ADDRESS,
-      chainTypesById[chainId],
+      chainId,
     ),
     relayVerifierAddress: getWalletSetting(
       SETTINGS.RELAY_VERIFIER_ADDRESS,
-      chainTypesById[chainId],
+      chainId,
     ),
     deployVerifierAddress: getWalletSetting(
       SETTINGS.DEPLOY_VERIFIER_ADDRESS,
-      chainTypesById[chainId],
+      chainId,
     ),
-    relayServer: getWalletSetting(
-      SETTINGS.RIF_RELAY_SERVER,
-      chainTypesById[chainId],
-    ),
+    relayServer: getWalletSetting(SETTINGS.RIF_RELAY_SERVER, chainId),
   }
 }
 
 const sslPinning = async (chainId: ChainID) => {
   const rifWalletServiceDomain = getWalletSetting(
     SETTINGS.RIF_WALLET_SERVICE_URL,
-    chainTypesById[chainId],
+    chainId,
   ).split('//')[1]
 
   const rifWalletServicePk = getWalletSetting(
     SETTINGS.RIF_WALLET_SERVICE_PUBLIC_KEY,
-    chainTypesById[chainId],
+    chainId,
   ).split(',')
   const rifRelayDomain = getWalletSetting(
     SETTINGS.RIF_RELAY_SERVER,
-    chainTypesById[chainId],
+    chainId,
   ).split('//')[1]
 
   const rifRelayPk = getWalletSetting(
     SETTINGS.RIF_RELAY_SERVER_PK,
-    chainTypesById[chainId],
+    chainId,
   ).split(',')
 
   await initializeSslPinning({
@@ -287,7 +284,7 @@ export const unlockApp = createAsyncThunk<
       return thunkAPI.rejectWithValue('Move to Offline Screen')
     }
 
-    const url = getWalletSetting(SETTINGS.RPC_URL, chainTypesById[chainId])
+    const url = getWalletSetting(SETTINGS.RPC_URL, chainId)
     const jsonRpcProvider = new providers.StaticJsonRpcProvider(url)
 
     const wallet = await loadAppWallet(

--- a/src/redux/slices/settingsSlice/index.ts
+++ b/src/redux/slices/settingsSlice/index.ts
@@ -28,10 +28,6 @@ import {
   SocketsEvents,
   socketsEvents,
 } from 'src/subscriptions/rifSockets'
-import {
-  chainTypesById,
-  ChainTypesByIdType,
-} from 'shared/constants/chainConstants'
 import { getCurrentChainId } from 'storage/ChainStorage'
 import { resetReduxStorage } from 'storage/ReduxStorage'
 import {
@@ -80,7 +76,7 @@ export const getRifRelayConfig = (chainId: 30 | 31): RifRelayConfig => {
   }
 }
 
-const sslPinning = async (chainId: ChainTypesByIdType) => {
+const sslPinning = async (chainId: ChainID) => {
   const rifWalletServiceDomain = getWalletSetting(
     SETTINGS.RIF_WALLET_SERVICE_URL,
     chainTypesById[chainId],
@@ -134,7 +130,6 @@ const initializeApp = async (
   // connect to sockets
   rifSockets({
     address: addressToUse(wallet),
-    fetcher: fetcherInstance,
     dispatch,
     setGlobalError: rejectWithValue,
     usdPrices,
@@ -164,7 +159,7 @@ export const createWallet = createAsyncThunk<
   try {
     const { chainId } = thunkAPI.getState().settings
 
-    const url = getWalletSetting(SETTINGS.RPC_URL, chainTypesById[chainId])
+    const url = getWalletSetting(SETTINGS.RPC_URL, chainId)
     const jsonRpcProvider = new providers.StaticJsonRpcProvider(url)
 
     const wallet = await createAppWallet(
@@ -392,7 +387,7 @@ const settingsSlice = createSlice({
     closeRequest: state => {
       state.requests.pop()
     },
-    setChainId: (state, { payload }: PayloadAction<ChainTypesByIdType>) => {
+    setChainId: (state, { payload }: PayloadAction<ChainID>) => {
       state.chainId = payload
     },
     setAppIsActive: (state, { payload }: PayloadAction<boolean>) => {

--- a/src/redux/slices/settingsSlice/types.ts
+++ b/src/redux/slices/settingsSlice/types.ts
@@ -1,9 +1,16 @@
 import { BitcoinNetworkWithBIPRequest } from '@rsksmart/rif-wallet-bitcoin'
 import { ColorValue } from 'react-native'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { RequestWithBitcoin } from 'shared/types'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 import { InitializeWallet, Wallet } from 'shared/wallet'
+
+export type ResetAppPayload =
+  | undefined
+  | {
+      wallet: Wallet
+    }
 
 export interface WalletIsDeployed {
   loading: boolean
@@ -71,7 +78,7 @@ export interface SettingsSlice {
   topColor: ColorValue
   selectedWallet: string
   loading: boolean
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   appIsActive: boolean
   unlocked: boolean
   previouslyUnlocked: boolean

--- a/src/redux/slices/transactionsSlice/index.ts
+++ b/src/redux/slices/transactionsSlice/index.ts
@@ -12,6 +12,7 @@ import {
   convertTokenToUSD,
   convertUnixTimeToFromNowFormat,
 } from 'lib/utils'
+import { ChainID } from 'lib/eoaWallet'
 
 import {
   ActivityMixedType,
@@ -27,18 +28,13 @@ import { resetSocketState } from 'store/shared/actions/resetSocketState'
 import { UsdPricesState } from 'store/slices/usdPricesSlice'
 import { getTokenAddress } from 'core/config'
 import { AsyncThunkWithTypes } from 'store/store'
-import {
-  ChainTypeEnum,
-  chainTypesById,
-  ChainTypesByIdType,
-} from 'shared/constants/chainConstants'
 import { TokenSymbol } from 'screens/home/TokenImage'
 import { rbtcMap } from 'shared/utils'
 
 export const activityDeserializer: (
   activityTransaction: ActivityMixedType,
   prices: UsdPricesState,
-  chainId: ChainTypesByIdType,
+  chainId: ChainID,
 ) => ActivityRowPresentationObject = (activityTransaction, prices, chainId) => {
   if ('isBitcoin' in activityTransaction) {
     const fee = activityTransaction.fees
@@ -82,10 +78,7 @@ export const activityDeserializer: (
     const etx = activityTransaction.enhancedTransaction
 
     // RBTC
-    const rbtcSymbol =
-      chainTypesById[chainId] === ChainTypeEnum.MAINNET
-        ? TokenSymbol.RBTC
-        : TokenSymbol.TRBTC
+    const rbtcSymbol = chainId === 30 ? TokenSymbol.RBTC : TokenSymbol.TRBTC
     const rbtcAddress = constants.AddressZero
     const feeRbtc = BigNumber.from(tx.receipt?.gasUsed || 0)
 

--- a/src/screens/activity/ActivityScreen.tsx
+++ b/src/screens/activity/ActivityScreen.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { FlatList, Image, RefreshControl, StyleSheet, View } from 'react-native'
 import { useIsFocused } from '@react-navigation/native'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { Typography } from 'components/typography'
 import { abiEnhancer } from 'core/setup'
 import { rootTabsRouteNames } from 'navigation/rootNavigator'
@@ -20,7 +22,6 @@ import {
 } from 'store/slices/transactionsSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'store/storeUtils'
 import { useWallet } from 'shared/wallet'
-import { ChainTypesByIdType } from 'src/shared/constants/chainConstants'
 
 import { ActivityBasicRow } from './ActivityRow'
 
@@ -116,7 +117,7 @@ const styles = StyleSheet.create({
 
 export const enhanceTransactionInput = async (
   transaction: IApiTransaction,
-  chainId: ChainTypesByIdType,
+  chainId: ChainID,
 ): Promise<EnhancedResult | null> => {
   try {
     const enhancedTx = await abiEnhancer.enhance(chainId, {

--- a/src/screens/rnsManager/types.ts
+++ b/src/screens/rnsManager/types.ts
@@ -1,4 +1,4 @@
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
+import { ChainID } from 'lib/eoaWallet'
 
 import { TESTNET, MAINNET } from './addresses.json'
 
@@ -9,10 +9,7 @@ export interface RNS_ADDRESSES_TYPE {
   rnsRegistryAddress: string
 }
 
-export const RNS_ADDRESSES_BY_CHAIN_ID: Record<
-  ChainTypesByIdType,
-  RNS_ADDRESSES_TYPE
-> = {
+export const RNS_ADDRESSES_BY_CHAIN_ID: Record<ChainID, RNS_ADDRESSES_TYPE> = {
   30: MAINNET,
   31: TESTNET,
 }

--- a/src/screens/send/TransactionForm.tsx
+++ b/src/screens/send/TransactionForm.tsx
@@ -16,6 +16,7 @@ import {
   sanitizeMaxDecimalText,
   shortAddress,
 } from 'lib/utils'
+import { ChainID } from 'lib/eoaWallet'
 
 import {
   AddressInput,
@@ -32,7 +33,6 @@ import { castStyle } from 'shared/utils'
 import { IPrice } from 'src/subscriptions/types'
 import { TokenBalanceObject } from 'store/slices/balancesSlice/types'
 import { Contact, ContactWithAddressRequired } from 'src/shared/types'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 import { navigationContainerRef } from 'src/core/Core'
 import { rootTabsRouteNames } from 'src/navigation/rootNavigator'
 import { contactsStackRouteNames } from 'src/navigation/contactsNavigator'
@@ -51,7 +51,7 @@ interface Props {
   isWalletDeployed: boolean
   tokenList: TokenBalanceObject[]
   tokenPrices: Record<string, IPrice>
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   totalUsdBalance: string
   initialValues: {
     asset?: TokenBalanceObject

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -35,25 +35,17 @@ export const SettingsScreen = ({
   const { walletIsDeployed } = useContext(WalletContext)
 
   const smartWalletFactoryAddress = useMemo(
-    () =>
-      getWalletSetting(
-        SETTINGS.SMART_WALLET_FACTORY_ADDRESS,
-        chainTypesById[chainId],
-      ),
+    () => getWalletSetting(SETTINGS.SMART_WALLET_FACTORY_ADDRESS, chainId),
     [chainId],
   )
 
   const rpcUrl = useMemo(
-    () => getWalletSetting(SETTINGS.RPC_URL, chainTypesById[chainId]),
+    () => getWalletSetting(SETTINGS.RPC_URL, chainId),
     [chainId],
   )
 
   const walletServiceUrl = useMemo(
-    () =>
-      getWalletSetting(
-        SETTINGS.RIF_WALLET_SERVICE_URL,
-        chainTypesById[chainId],
-      ),
+    () => getWalletSetting(SETTINGS.RIF_WALLET_SERVICE_URL, chainId),
     [chainId],
   )
 

--- a/src/screens/transactionSummary/TransactionSummaryComponent.tsx
+++ b/src/screens/transactionSummary/TransactionSummaryComponent.tsx
@@ -20,9 +20,8 @@ import { DollarIcon } from 'components/icons/DollarIcon'
 import { FullScreenSpinner } from 'components/fullScreenSpinner'
 import { getContactByAddress } from 'store/slices/contactsSlice'
 import { getWalletSetting } from 'src/core/config'
-import { SETTINGS } from 'src/core/types'
-import { chainTypesById } from 'src/shared/constants/chainConstants'
-import { selectChainId } from 'src/redux/slices/settingsSlice'
+import { SETTINGS } from 'core/types'
+import { selectChainId } from 'store/slices/settingsSlice'
 
 import { TokenImage } from '../home/TokenImage'
 import {
@@ -101,7 +100,7 @@ export const TransactionSummaryComponent = ({
       ? SETTINGS.BTC_EXPLORER_ADDRESS_URL
       : SETTINGS.EXPLORER_ADDRESS_URL
 
-    const explorerUrl = getWalletSetting(setting, chainTypesById[chainId])
+    const explorerUrl = getWalletSetting(setting, chainId)
     Linking.openURL(`${explorerUrl}/${hashId}`)
   }
 

--- a/src/screens/walletConnect/ScanQRScreen.tsx
+++ b/src/screens/walletConnect/ScanQRScreen.tsx
@@ -13,7 +13,6 @@ import {
 } from 'navigation/rootNavigator'
 import { selectChainId } from 'store/slices/settingsSlice'
 import { useAppSelector } from 'store/storeUtils'
-import { chainTypesById } from 'shared/constants/chainConstants'
 import { AndroidQRScanner } from 'screens/walletConnect/AndroidQRScanner'
 
 export const ScanQRScreen = ({

--- a/src/screens/walletConnect/ScanQRScreen.tsx
+++ b/src/screens/walletConnect/ScanQRScreen.tsx
@@ -41,7 +41,7 @@ export const ScanQRScreen = ({
       // Default bitcoin token will be fetched from ENV
       const defaultToken = getWalletSetting(
         SETTINGS.QR_READER_BITCOIN_DEFAULT_NETWORK,
-        chainTypesById[chainId],
+        chainId,
       )
       navigation.navigate(rootTabsRouteNames.Home, {
         screen: homeStackRouteNames.Send,

--- a/src/screens/walletConnect/WalletConnect2Context.tsx
+++ b/src/screens/walletConnect/WalletConnect2Context.tsx
@@ -10,13 +10,14 @@ import Web3Wallet, { Web3WalletTypes } from '@walletconnect/web3wallet'
 import { IWeb3Wallet } from '@walletconnect/web3wallet'
 import { WalletConnectAdapter } from '@rsksmart/rif-wallet-adapters'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import {
   buildRskAllowedNamespaces,
   createWeb3Wallet,
   getProposalErrorComparedWithRskNamespace,
   WalletConnect2SdkErrorString,
 } from 'screens/walletConnect/walletConnect2.utils'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 import { useAppDispatch, useAppSelector } from 'store/storeUtils'
 import { selectChainId } from 'store/slices/settingsSlice'
 import { addPendingTransaction } from 'store/slices/transactionsSlice'
@@ -26,7 +27,7 @@ const onSessionApprove = async (
   web3wallet: Web3Wallet,
   proposal: Web3WalletTypes.SessionProposal,
   walletAddress: string,
-  chainId: ChainTypesByIdType,
+  chainId: ChainID,
 ) => {
   try {
     const namespaces = buildRskAllowedNamespaces({

--- a/src/screens/walletConnect/walletConnect2.utils.ts
+++ b/src/screens/walletConnect/walletConnect2.utils.ts
@@ -2,9 +2,10 @@ import { Core } from '@walletconnect/core'
 import { Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import { getSdkError, buildApprovedNamespaces } from '@walletconnect/utils'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { getEnvSetting } from 'core/config'
 import { SETTINGS } from 'core/types'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 import { AcceptedValue, MMKVStorage } from 'storage/MMKVStorage'
 
 export type WalletConnect2SdkErrorString = Parameters<typeof getSdkError>[0]
@@ -93,7 +94,7 @@ const WALLETCONNECT_SUPPORTED_METHODS = [
   'eth_signTypedData',
 ]
 
-const WALLETCONNECT_BUILD_SUPPORTED_CHAINS = (chainId: ChainTypesByIdType) => [
+const WALLETCONNECT_BUILD_SUPPORTED_CHAINS = (chainId: ChainID) => [
   `eip155:${chainId}`,
 ]
 
@@ -102,7 +103,7 @@ const WALLETCONNECT_BUILD_SUPPORTED_ACCOUNTS = ({
   chainId,
 }: {
   walletAddress: string
-  chainId: ChainTypesByIdType
+  chainId: ChainID
 }) => [`eip155:${chainId}:${walletAddress}`]
 
 const WALLETCONNECT_SUPPORTED_EVENTS = ['accountsChanged', 'chainChanged']
@@ -113,7 +114,7 @@ export const buildRskAllowedNamespaces = ({
   walletAddress,
 }: {
   proposal: Web3WalletTypes.SessionProposal
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   walletAddress: string
 }) =>
   buildApprovedNamespaces({

--- a/src/shared/constants/chainConstants.ts
+++ b/src/shared/constants/chainConstants.ts
@@ -17,5 +17,3 @@ export const chainTypesById = {
   30: ChainTypeEnum.MAINNET,
   31: ChainTypeEnum.TESTNET,
 }
-
-export type ChainTypesByIdType = keyof typeof chainTypesById

--- a/src/shared/constants/chainConstants.ts
+++ b/src/shared/constants/chainConstants.ts
@@ -2,14 +2,6 @@ export enum ChainTypeEnum {
   TESTNET = 'TESTNET',
   MAINNET = 'MAINNET',
 }
-
-/**
- * Object that has chainTypes IDs
- */
-export const chainTypes = {
-  [ChainTypeEnum.MAINNET]: 30,
-  [ChainTypeEnum.TESTNET]: 31,
-}
 /**
  * Object that has the ChainTypeEnum by ID
  */

--- a/src/storage/ChainStorage.ts
+++ b/src/storage/ChainStorage.ts
@@ -1,10 +1,11 @@
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
+import { ChainID } from 'lib/eoaWallet'
+
 import { MMKVStorage } from 'storage/MMKVStorage'
 
 const ChainStorage = new MMKVStorage('chainStorage')
 
-export const getCurrentChainId: () => ChainTypesByIdType = () =>
+export const getCurrentChainId: () => ChainID = () =>
   ChainStorage.get('chainId') || 31
 
-export const setCurrentChainId = (chainId: ChainTypesByIdType) =>
+export const setCurrentChainId = (chainId: ChainID) =>
   ChainStorage.set('chainId', chainId)

--- a/src/subscriptions/onSocketChangeEmitted.ts
+++ b/src/subscriptions/onSocketChangeEmitted.ts
@@ -1,6 +1,8 @@
 import { IApiTransaction } from '@rsksmart/rif-wallet-services'
 import { EnhancedResult, IAbiEnhancer } from '@rsksmart/rif-wallet-abi-enhancer'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { resetSocketState } from 'store/shared/actions/resetSocketState'
 import { addOrUpdateBalances } from 'store/slices/balancesSlice'
 import {
@@ -13,7 +15,6 @@ import {
 } from 'store/slices/transactionsSlice'
 import { UsdPricesState, setUsdPrices } from 'store/slices/usdPricesSlice'
 import { AppDispatch } from 'store/index'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 import { getCurrentChainId } from 'storage/ChainStorage'
 import { enhanceTransactionInput } from 'src/screens/activity/ActivityScreen'
 import { MMKVStorage } from 'storage/MMKVStorage'
@@ -24,14 +25,14 @@ interface OnNewTransactionEventEmittedArgs {
   dispatch: AppDispatch
   payload: IApiTransaction
   usdPrices: UsdPricesState
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   abiEnhancer: IAbiEnhancer
 }
 
 interface OnSocketChangeEmittedArgs {
   dispatch: AppDispatch
   usdPrices: UsdPricesState
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   abiEnhancer: IAbiEnhancer
   cache: MMKVStorage
 }

--- a/src/subscriptions/rifSockets.ts
+++ b/src/subscriptions/rifSockets.ts
@@ -5,6 +5,8 @@ import {
 } from '@rsksmart/rif-wallet-services'
 import DeviceInfo from 'react-native-device-info'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { resetSocketState } from 'store/shared/actions/resetSocketState'
 import { AppDispatch } from 'store/index'
 import { abiEnhancer, getDefaultTokens } from 'core/setup'
@@ -13,10 +15,6 @@ import { TokenBalanceObject } from 'store/slices/balancesSlice/types'
 import { UsdPricesState } from 'store/slices/usdPricesSlice'
 import { getWalletSetting } from 'core/config'
 import { SETTINGS } from 'core/types'
-import {
-  chainTypesById,
-  ChainTypesByIdType,
-} from 'shared/constants/chainConstants'
 import { MMKVStorage } from 'storage/MMKVStorage'
 
 import { onSocketChangeEmitted } from './onSocketChangeEmitted'
@@ -31,7 +29,7 @@ export enum SocketsEvents {
 
 interface RifSockets {
   address: string
-  chainId: ChainTypesByIdType
+  chainId: ChainID
   setGlobalError: (err: string) => void
   dispatch: AppDispatch
   usdPrices: UsdPricesState
@@ -63,7 +61,7 @@ export const rifSockets = ({
     cache,
   })
   const rifWalletServicesSocket = new RifWalletServicesSocket(
-    getWalletSetting(SETTINGS.RIF_WALLET_SERVICE_URL, chainTypesById[chainId]),
+    getWalletSetting(SETTINGS.RIF_WALLET_SERVICE_URL, chainId),
   )
 
   const connectSocket = () => {

--- a/src/ux/requestsModal/ReviewRelayTransaction/ReviewTransactionContainer.tsx
+++ b/src/ux/requestsModal/ReviewRelayTransaction/ReviewTransactionContainer.tsx
@@ -18,15 +18,12 @@ import { TokenSymbol } from 'screens/home/TokenImage'
 import { TransactionSummaryScreenProps } from 'screens/transactionSummary'
 import { TransactionSummaryComponent } from 'screens/transactionSummary/TransactionSummaryComponent'
 import { sharedColors } from 'shared/constants'
-import { chainTypesById } from 'shared/constants/chainConstants'
 import {
   castStyle,
   errorHandler,
   formatTokenValues,
   rbtcMap,
 } from 'shared/utils'
-import { selectChainId } from 'store/slices/settingsSlice'
-import { ChainTypeEnum } from 'store/slices/settingsSlice/types'
 import { selectUsdPrices } from 'store/slices/usdPricesSlice'
 import { useAppDispatch, useAppSelector } from 'store/storeUtils'
 import { addRecentContact } from 'store/slices/contactsSlice'
@@ -34,6 +31,7 @@ import { selectBalances } from 'store/slices/balancesSlice'
 import { selectRecentRskTransactions } from 'store/slices/transactionsSlice'
 import { WalletContext } from 'shared/wallet'
 import { useAddress } from 'shared/hooks'
+import { getCurrentChainId } from 'src/storage/ChainStorage'
 
 import { useEnhancedWithGas } from '../useEnhancedWithGas'
 
@@ -70,7 +68,7 @@ export const ReviewTransactionContainer = ({
   // enhance the transaction to understand what it is:
   const { wallet } = useContext(WalletContext)
   const address = useAddress(wallet)
-  const chainId = useAppSelector(selectChainId)
+  const chainId = getCurrentChainId()
   const balances = useAppSelector(selectBalances)
   const pendingTransactions = useAppSelector(selectRecentRskTransactions)
   const [txCost, setTxCost] = useState<BigNumber>()
@@ -97,8 +95,7 @@ export const ReviewTransactionContainer = ({
     gasLimit,
   } = enhancedTransactionRequest
 
-  const isMainnet = chainTypesById[chainId] === ChainTypeEnum.MAINNET
-  const feeSymbol = getFeeSymbol(isMainnet, wallet instanceof RelayWallet)
+  const feeSymbol = getFeeSymbol(chainId === 30, wallet instanceof RelayWallet)
   const feeContract = getTokenAddress(feeSymbol, chainId)
 
   const getTokenBySymbol = useCallback(

--- a/src/ux/requestsModal/useEnhancedWithGas.ts
+++ b/src/ux/requestsModal/useEnhancedWithGas.ts
@@ -4,9 +4,10 @@ import { BigNumber } from 'ethers'
 import { AbiEnhancer } from '@rsksmart/rif-wallet-abi-enhancer'
 import { isAddress } from '@rsksmart/rsk-utils'
 
+import { ChainID } from 'lib/eoaWallet'
+
 import { TokenSymbol } from 'screens/home/TokenImage'
 import { Wallet } from 'shared/wallet'
-import { ChainTypesByIdType } from 'shared/constants/chainConstants'
 
 const abiEnhancer = new AbiEnhancer()
 
@@ -33,7 +34,7 @@ export interface EnhancedTransactionRequest extends TransactionRequest {
 export const useEnhancedWithGas = (
   wallet: Wallet,
   tx: TransactionRequest,
-  chainId: ChainTypesByIdType,
+  chainId: ChainID,
 ) => {
   const [enhancedTransactionRequest, setEnhancedTransactionRequest] =
     useState<EnhancedTransactionRequest>({


### PR DESCRIPTION
Not that we have `ChainID` type from `EOAWallet` we can use it. @jormelCoin make sure nothing breaks after this PR.