### PR TITLE
US-2154 Fixed bitcoin error when sending btc

### DIFF
--- a/src/ux/requestsModal/ReviewBitcoinTransactionContainer.tsx
+++ b/src/ux/requestsModal/ReviewBitcoinTransactionContainer.tsx
@@ -84,6 +84,7 @@ export const ReviewBitcoinTransactionContainer = ({
     const amountToPayUsd = convertToUSD(amountToPay)
     const feeUsd = convertToUSD(miningFee)
     const isAmountSmall = !Number(amountToPayUsd) && !!Number(amountToPay)
+    const totalSent = Number(amountToPay) + Number(miningFee)
 
     return {
       transaction: {
@@ -107,6 +108,10 @@ export const ReviewBitcoinTransactionContainer = ({
           tokenValue: amountToPay,
           usdValue: formatTokenValues(Number(amountToPayUsd) + Number(feeUsd)),
         },
+        totalToken: totalSent,
+        totalUsd: Number(
+          formatTokenValues(Number(amountToPayUsd) + Number(feeUsd)),
+        ),
         to: addressToPay,
       },
       buttons: [


### PR DESCRIPTION
Now the error will not show and the tx sum component will show the appropiate data.

How to test:
1-Go to send screen
2-Send btc
3-Input address & amount
4-Click on send
5-The modal should appear