### PR TITLE
fix for fee symbol in eoa wallet

### DIFF
--- a/src/screens/send/TransactionForm.tsx
+++ b/src/screens/send/TransactionForm.tsx
@@ -28,7 +28,7 @@ import {
 } from 'components/index'
 import { CurrencyValue, TokenBalance } from 'components/token'
 import { defaultIconSize, sharedColors, testIDs } from 'shared/constants'
-import { castStyle } from 'shared/utils'
+import { castStyle, useRelay } from 'shared/utils'
 import { IPrice } from 'src/subscriptions/types'
 import { TokenBalanceObject } from 'store/slices/balancesSlice/types'
 import { Contact, ContactWithAddressRequired } from 'src/shared/types'
@@ -85,6 +85,11 @@ const rifFeeMap = new Map([
   [TokenSymbol.RIF, true],
 ])
 
+const rbtcFeeMap = new Map([
+  [TokenSymbol.TRBTC, true],
+  [TokenSymbol.RBTC, true],
+])
+
 const transactionSchema = yup.object().shape({
   amount: yup.number().min(0.000000001),
   to: yup.object({
@@ -115,6 +120,10 @@ export const TransactionForm = ({
     () => tokenList.filter(tk => rifFeeMap.get(tk.symbol as TokenSymbol))[0],
     [tokenList],
   )
+  const rbtcToken = useMemo(
+    () => tokenList.filter(tk => rbtcFeeMap.get(tk.symbol as TokenSymbol))[0],
+    [tokenList],
+  )
   const insets = useSafeAreaInsets()
   const { recipient, asset, amount: initialAmount } = initialValues
   const { t } = useTranslation()
@@ -134,9 +143,13 @@ export const TransactionForm = ({
     if (bitcoinFeeMap.get(selectedToken.symbol as TokenSymbol)) {
       return selectedToken
     } else {
-      return rifToken
+      if (useRelay) {
+        return rifToken
+      } else {
+        return rbtcToken
+      }
     }
-  }, [selectedToken, rifToken])
+  }, [selectedToken, rifToken, rbtcToken])
 
   const tokenQuote = selectedToken.contractAddress.startsWith('BITCOIN')
     ? tokenPrices.BTC.price

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -2,7 +2,6 @@ import { version } from 'package.json'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, ScrollView, StyleSheet, View } from 'react-native'
-import Config from 'react-native-config'
 
 import { AppTouchable, Typography } from 'components/index'
 import { getWalletSetting } from 'core/config'
@@ -13,7 +12,7 @@ import {
   settingsStackRouteNames,
 } from 'navigation/settingsNavigator/types'
 import { sharedColors, sharedStyles } from 'shared/constants'
-import { castStyle } from 'shared/utils'
+import { castStyle, useRelay } from 'shared/utils'
 import { selectChainId } from 'store/slices/settingsSlice'
 import { selectPin } from 'store/slices/persistentDataSlice'
 import { useAppSelector } from 'store/storeUtils'
@@ -156,7 +155,7 @@ export const SettingsScreen = ({
         <View style={styles.settingsItem}>
           <Typography type={'h4'} color={sharedColors.labelLight}>
             {t('settings_screen_version')} {version}-
-            {Config.USE_RELAY ? 'relay' : 'eoa'}
+            {useRelay ? 'relay' : 'eoa'}
           </Typography>
         </View>
 

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -259,3 +259,5 @@ export const loadAppWallet = async (
 
   return wallet
 }
+
+export const useRelay = Config.USE_RELAY === 'true'


### PR DESCRIPTION
The fee for a transaction in an EOA Wallet should be native cryptocurrency(RBTC)

I added a few lines to show this token for EOA Wallet.

What do you think?
Result:
<img width="303" alt="Screenshot 2024-02-08 at 11 03 53" src="https://github.com/rsksmart/rif-wallet/assets/96137983/f5f57fcc-bb7f-431f-9bee-440fe6999ea4">
