### PR TITLE
refactor: add loading to ImportWallet and prevent double-tap

### DIFF
--- a/src/redux/slices/settingsSlice/selectors.ts
+++ b/src/redux/slices/settingsSlice/selectors.ts
@@ -4,20 +4,6 @@ export const selectRequests = ({ settings }: RootState) => settings.requests
 
 export const selectTopColor = ({ settings }: RootState) => settings.topColor
 
-export const selectWallet = ({ settings }: RootState) => {
-  if (!settings.wallets) {
-    throw new Error('No Wallets set!')
-  }
-
-  return settings.wallets[settings.selectedWallet]
-}
-
-export const selectWalletIsDeployed = ({ settings }: RootState) => {
-  if (!settings.walletsIsDeployed) {
-    throw new Error('WalletIsDeployed is not set!')
-  }
-  return settings.walletsIsDeployed[settings.selectedWallet]
-}
 export const selectSettingsIsLoading = ({ settings }: RootState) =>
   settings.loading
 
@@ -41,16 +27,3 @@ export const selectHideBalance = ({ settings }: RootState) =>
 export const selectBitcoin = ({ settings }: RootState) => settings.bitcoin
 
 export const selectChainId = ({ settings }: RootState) => settings.chainId
-
-export const selectWalletState = ({
-  settings: { wallets, walletsIsDeployed, chainId, selectedWallet },
-}: RootState) => {
-  if (!wallets || !walletsIsDeployed) {
-    throw new Error('No Wallet exist in state')
-  }
-  return {
-    wallet: wallets[selectedWallet],
-    walletIsDeployed: walletsIsDeployed[selectedWallet],
-    chainId,
-  }
-}


### PR DESCRIPTION

https://github.com/rsksmart/rif-wallet/assets/47615361/1d28d612-966a-4f3e-853d-4db996f1ad16

Still some improvements left. We need to figure out why it freezes before `LoadingScreen` opens