### PR TITLE
US-2163 Confirmation screen fails when leaving the app

### DIFF
--- a/src/core/Core.tsx
+++ b/src/core/Core.tsx
@@ -36,7 +36,7 @@ export const Core = () => {
   const topColor = useAppSelector(selectTopColor)
   const setGlobalError = useSetGlobalError()
   const isOffline = useIsOffline()
-  const { active } = useStateSubscription()
+  const { active, unlocked } = useStateSubscription()
   const { wallet, initializeWallet } = useContext(WalletContext)
 
   const unlockAppFn = useCallback(async () => {
@@ -62,7 +62,7 @@ export const Core = () => {
           <WalletConnect2Provider wallet={wallet}>
             <>
               <RootNavigationComponent />
-              {requests.length !== 0 && wallet && (
+              {requests.length !== 0 && wallet && unlocked && (
                 <RequestHandler
                   wallet={wallet}
                   request={requests[0]}

--- a/src/core/hooks/useStateSubscription.ts
+++ b/src/core/hooks/useStateSubscription.ts
@@ -7,6 +7,8 @@ import {
   setPreviouslyUnlocked,
   setUnlocked as setIsUnlocked,
   unlockApp,
+  closeRequest,
+  setFullscreen,
 } from 'store/slices/settingsSlice'
 import { useAppDispatch, useAppSelector } from 'store/storeUtils'
 import { SocketsEvents, socketsEvents } from 'src/subscriptions/rifSockets'
@@ -52,6 +54,9 @@ export const useStateSubscription = () => {
 
           setUnlocked(false)
           dispatch(setPreviouslyUnlocked(true))
+          // request needs to be reset when gracePeriod is over
+          dispatch(closeRequest())
+          dispatch(setFullscreen(false))
           //reset wallet state
           setWallet(null)
           setWalletIsDeployed(null)


### PR DESCRIPTION
@jormelCoin 
Closing the request and reloading the app is expected when `gracePeriod` is over.
https://github.com/rsksmart/rif-wallet/assets/47615361/312a80e9-9dec-43ef-92fd-e0208d97e980

